### PR TITLE
사용자 방 참여 시 전달되는 데이터 변경 / 공감 포인트 모으기 시작 시 모든 참여자에게 주제와 종료시간 전달

### DIFF
--- a/backend/src/rooms/dto/rooms.join.dto.ts
+++ b/backend/src/rooms/dto/rooms.join.dto.ts
@@ -2,5 +2,5 @@ import { RoomsParticipantDto } from './rooms.participant.dto';
 
 export class RoomsJoinDto {
   participants: RoomsParticipantDto[];
-  hostFlag: boolean;
+  hostId: string;
 }

--- a/backend/src/rooms/entity/Room.ts
+++ b/backend/src/rooms/entity/Room.ts
@@ -12,9 +12,9 @@ export class Room {
     const nowParticipants: RoomsParticipantDto[] =
       this.participants.map(participant => new RoomsParticipantDto(participant));
 
-    const hostFlag = this.participants[0] === client;
+    const hostId = this.participants[0].id;
 
-    return { participants: nowParticipants, hostFlag };
+    return { participants: nowParticipants, hostId };
   }
 
   exit(client: Socket) {

--- a/backend/src/rooms/entity/Topic.ts
+++ b/backend/src/rooms/entity/Topic.ts
@@ -1,0 +1,13 @@
+export class Topic {
+  private readonly id: number;
+  private readonly title: string;
+  private readonly expirationTime: string;
+
+  constructor(id: number, title: string, addSecond: number) {
+    this.id = id;
+    this.title = title;
+    const date = new Date();
+    date.setSeconds(date.getSeconds() + addSecond);
+    this.expirationTime = date.toISOString();
+  }
+}

--- a/backend/src/rooms/gateway/rooms.gateway.ts
+++ b/backend/src/rooms/gateway/rooms.gateway.ts
@@ -58,6 +58,23 @@ export class RoomsGateway implements OnGatewayDisconnect {
     this.server.to(roomId).emit('participant:info:update', { participantId: client.id, nickname });
   }
 
+  @SubscribeMessage('participant:host:start')
+  startToEmpathise(@ConnectedSocket() client: Socket): void {
+    const roomId = client.data.roomId;
+
+    if (roomId === undefined) {
+      throw new WsException('방에 참가하지 않으셨습니다.');
+    }
+
+    if (!this.roomsService.isHost(client)) {
+      throw new WsException('호스트가 아닙니다.');
+    }
+
+    const empathyTopics = this.roomsService.getEmpathyTopics();
+
+    this.server.to(roomId).emit('empathy:start', { questions: empathyTopics });
+  }
+
   handleDisconnect(client: Socket): void {
     const roomId = client.data.roomId;
 

--- a/backend/src/rooms/service/rooms.service.ts
+++ b/backend/src/rooms/service/rooms.service.ts
@@ -62,8 +62,16 @@ export class RoomsService {
 
   getEmpathyTopics(count = 5, topicSecond = 60, topicTermSecond = 1) {
     count = Math.min(this.topicTitles.length, count);
-    return this.topicTitles.sort(() => Math.random() - 0.5)
-      .slice(0, count)
+
+    const randomTopicTitles = [...this.topicTitles];
+
+    for (let i = randomTopicTitles.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+
+      [randomTopicTitles[i], randomTopicTitles[j]] = [randomTopicTitles[j], randomTopicTitles[i]];
+    }
+
+    return randomTopicTitles.slice(0, count)
       .map((title, index) => new Topic(index + 1, title, (index + 1) * (topicSecond + topicTermSecond)));
   }
 }

--- a/backend/src/rooms/service/rooms.service.ts
+++ b/backend/src/rooms/service/rooms.service.ts
@@ -3,6 +3,7 @@ import { Room } from '../entity/Room';
 import { v4 as uuid } from 'uuid';
 import { Socket } from 'socket.io';
 import { RoomsJoinDto } from '../dto/rooms.join.dto';
+import { Topic } from '../entity/Topic';
 
 @Injectable()
 export class RoomsService {
@@ -16,6 +17,13 @@ export class RoomsService {
 
   isExistRoom(roomId: string) {
     return this.rooms.has(roomId);
+  }
+
+  isHost(client: Socket) {
+    const roomId = client.data.roomId;
+    const room = this.rooms.get(roomId);
+    const { participantId: hostId } = room.getHostInfo();
+    return hostId === client.id;
   }
 
   join(client: Socket, roomId: string): RoomsJoinDto {
@@ -42,5 +50,20 @@ export class RoomsService {
   getHostInfo(roomId: string) {
     const room = this.rooms.get(roomId);
     return room.getHostInfo();
+  }
+
+  private readonly topicTitles: string[] = [
+    '좋아하는 음식은?',
+    '좋아하는 노래는?',
+    '좋아하는 아티스트는?',
+    '좋아하는 동물은?',
+    '좋아하는 게임은?',
+  ];
+
+  getEmpathyTopics(count = 5, topicSecond = 60, topicTermSecond = 1) {
+    count = Math.min(this.topicTitles.length, count);
+    return this.topicTitles.sort(() => Math.random() - 0.5)
+      .slice(0, count)
+      .map((title, index) => new Topic(index + 1, title, (index + 1) * (topicSecond + topicTermSecond)));
   }
 }


### PR DESCRIPTION
# ✅ 주요 작업
- 사용자가 방 참여 시 '본인의 호스트 유무'가 아닌 '해당 방의 호스트 id를 획득'하도록 변경
- 호스트가 시작 버튼을 누를 시 모든 참여자에게 '주제와 각 종료시간'이 전달

![image](https://github.com/user-attachments/assets/49d3a4e0-4ffe-4f36-83fc-9d1f8162f10f)

# 📚 학습 키워드
- Date
- toIsoString

# 💭 고민과 해결과정
## 참여자가 주제의 종료시간을 늘린다면?
특정 주제에서 참여자들이 키워드 입력 시간을 늘리고 싶을 때가 있을 것입니다.

아직 해당 사항을 개발하지는 않았지만, 이벤트로 만들어 클라이언트가 서버에게 이벤트를 요청하고, 서버가 해당 이벤트를 방 참여자들에게 브로드캐스팅한다면 될 듯 합니다.

## IsoString으로 전달하는 이유는?
클라이언트가 해당 값을 잘 다루기 위해서는 timestamp를 전달하는 게 낫다고 생각했습니다.

하지만 FE 담당자분과 이야기를 나눈 결과, 서버에서 IsoString 형태로 전달해야 '제대로 된 시간값이 오는구나'를 편하게 확인할 수 있다는 이야기가 도출되었습니다.

# 📌 이슈 사항
- 현재 start를 여러 번 중복적으로 누를 수 있습니다. 이는 아래와 같은 내용에 대해 의도되었습니다.
  - 아직 room의 state(혹은 phase)에 대해 설정하지 않았음
  - 개발 과정이므로 클라이언트가 해당 버튼을 통해 값이 오고가는 과정을 여러 번 테스트하는 상황을 가정
- 호스트가 아닌 사용자가 버튼을 눌렀을 때 아무런 응답이 전달되지 않고 있습니다. 이는 호스트만 시작할 수 있음을 확인할 수 있습니다. 다만 아래와 같은 문제가 있습니다.
  - nest에서 WsException을 발생 시 응답으로 error status가 전달되지 않는 문제가 있습니다.
  - nest의 코드 동작을 살펴본 후, 당장 수정할 수 없는 문제라면 클라이언트가 error 이벤트에 대해 listen하는 방향으로 구현해봐야 할 듯 합니다.