### PR TITLE
로딩 스피너 및 페이지 구현

### DIFF
--- a/frontend/src/components/RoomCreateButton.tsx
+++ b/frontend/src/components/RoomCreateButton.tsx
@@ -1,19 +1,27 @@
+import { hoverGrowJumpAnimation } from '../styles';
 import { useNavigate } from 'react-router-dom';
 import { Variables } from '../styles/Variables';
 import { css } from '@emotion/react';
+import { useState } from 'react';
+import { Toast } from './common';
+import CheckIcon from '../assets/icons/check.svg?react';
 
-const startButtonStyle = css({
-  font: Variables.typography.font_bold_24,
-  color: Variables.colors.text_white,
-  backgroundColor: Variables.colors.surface_point,
-  padding: '24px 48px',
-  borderRadius: 32,
-  ':hover': {
-    opacity: 0.8
-  }
-});
+const startButtonStyle = css(
+  {
+    font: Variables.typography.font_bold_24,
+    color: Variables.colors.text_white,
+    backgroundColor: Variables.colors.surface_point,
+    padding: '24px 48px',
+    borderRadius: 32,
+    ':hover': {
+      opacity: 0.8
+    }
+  },
+  hoverGrowJumpAnimation()
+);
 
 const RoomCreateButton = () => {
+  const [toast, setToast] = useState(false);
   const navigate = useNavigate();
 
   const createRoom = async () => {
@@ -30,14 +38,23 @@ const RoomCreateButton = () => {
         if (roomUrl) navigate(roomUrl.pathname);
       } else {
         console.error('Failed to create room');
+        setToast(true);
       }
     } catch (error) {
       console.error('Error creating room:', error);
+      setToast(true);
     }
   };
 
   return (
     <div>
+      {toast && (
+        <Toast
+          icon={() => <CheckIcon css={{ fill: Variables.colors.text_word_weak }} />}
+          text="서버와 통신 중 에러가 발생했습니다!"
+          setToast={setToast}
+        />
+      )}
       <button onClick={createRoom} css={startButtonStyle}>
         공감 포인트 나누기 시작하기
       </button>

--- a/frontend/src/components/RoomCreateButton.tsx
+++ b/frontend/src/components/RoomCreateButton.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Variables } from '../styles/Variables';
 import { css } from '@emotion/react';
 import { useState } from 'react';
-import { Toast } from './common';
+import { LoadingSpinner, Toast } from './common';
 import CheckIcon from '../assets/icons/check.svg?react';
 
 const startButtonStyle = css(
@@ -13,6 +13,8 @@ const startButtonStyle = css(
     backgroundColor: Variables.colors.surface_point,
     padding: '24px 48px',
     borderRadius: 32,
+    minWidth: '23.6rem',
+    minHeight: '5.1875rem',
     ':hover': {
       opacity: 0.8
     }
@@ -21,11 +23,13 @@ const startButtonStyle = css(
 );
 
 const RoomCreateButton = () => {
+  const [loading, setLoading] = useState(false);
   const [toast, setToast] = useState(false);
   const navigate = useNavigate();
 
   const createRoom = async () => {
     try {
+      setLoading(true);
       const response = await fetch('http://localhost:8080/rooms', {
         method: 'POST',
         headers: {
@@ -43,6 +47,8 @@ const RoomCreateButton = () => {
     } catch (error) {
       console.error('Error creating room:', error);
       setToast(true);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -56,7 +62,17 @@ const RoomCreateButton = () => {
         />
       )}
       <button onClick={createRoom} css={startButtonStyle}>
-        공감 포인트 나누기 시작하기
+        {loading ? (
+          <div css={{ display: 'flex', justifyContent: 'center' }}>
+            <LoadingSpinner
+              roundSize="1.7rem"
+              emptyColor={`${Variables.colors.surface_white}50`}
+              fillColor={Variables.colors.surface_white}
+            />
+          </div>
+        ) : (
+          '공감 포인트 나누기 시작하기'
+        )}
       </button>
     </div>
   );

--- a/frontend/src/components/common/LoadingSpinner.tsx
+++ b/frontend/src/components/common/LoadingSpinner.tsx
@@ -1,0 +1,31 @@
+import { css } from '@emotion/react';
+import { Variables } from '../../styles/Variables';
+import { parseNumberAndUnit } from '../../utils';
+import { rotate } from '../../styles';
+
+const spinnerStyle = (roundSize: string, width: string, emptyColor: string, fillColor: string, speed: string) =>
+  css({
+    width: roundSize,
+    height: roundSize,
+    borderRadius: '50%',
+    border: `solid ${width} ${emptyColor}`,
+    borderTop: `solid ${width} ${fillColor}`,
+    animation: `${rotate} ${speed} ease-in-out infinite`
+  });
+
+function divideSize(size: string, divisor: number) {
+  const [number, unit] = parseNumberAndUnit(size);
+  return `${(number / divisor).toFixed(3)}${unit}`;
+}
+
+const LoadingSpinner = ({
+  roundSize = '0.9rem',
+  width = divideSize(roundSize, 6.5),
+  emptyColor = Variables.colors.surface_alt,
+  fillColor = Variables.colors.surface_strong,
+  speed = '0.77s'
+}) => {
+  return <div css={spinnerStyle(roundSize, width, emptyColor, fillColor, speed)}></div>;
+};
+
+export default LoadingSpinner;

--- a/frontend/src/components/common/LoadingSpinnerWave.tsx
+++ b/frontend/src/components/common/LoadingSpinnerWave.tsx
@@ -68,7 +68,7 @@ const LoadingSpinnerWave = ({ delay = DEFAULT_DELAY, roundSize = '2.5rem' }) => 
       <Round
         roundSize={roundSize}
         duration={delay * 10}
-        colorStartIndex={Math.floor((2 * HUE_MAX_INDEX) / 4)}
+        colorStartIndex={Math.floor((2.5 * HUE_MAX_INDEX) / 4)}
         delay={delay * 3}
       />
     </div>

--- a/frontend/src/components/common/LoadingSpinnerWave.tsx
+++ b/frontend/src/components/common/LoadingSpinnerWave.tsx
@@ -1,0 +1,78 @@
+import { css } from '@emotion/react';
+import { growAndShrink } from '../../styles';
+import { useIndex } from '../../hooks';
+
+const DEFAULT_DELAY = 0.165;
+const COLOR_DIFF = 40;
+const HUE_MAX_VALUE = 360;
+const HUE_MAX_INDEX = Math.ceil(HUE_MAX_VALUE / COLOR_DIFF);
+
+function getPastelColor(index: number) {
+  const SATURATION = '82%';
+  const LIGHTNESS = '89%';
+  const ALPHA = '0.7';
+
+  return `hsla(${COLOR_DIFF * index}, ${SATURATION}, ${LIGHTNESS}, ${ALPHA})`;
+}
+
+const roundStyle = (color: string, duration: number, roundSize: string, delay: number = 0) => {
+  return css({
+    width: roundSize,
+    height: roundSize,
+    borderRadius: '50%',
+    position: 'relative',
+    backgroundColor: color,
+
+    transform: 'scale(0)',
+    animation: `${growAndShrink} ${duration}s ease-in-out infinite`,
+    animationDelay: `${delay}s`
+  });
+};
+
+const loadingSpinnerWaveStyle = css({
+  display: 'flex',
+  gap: '0.5rem',
+  position: 'relative',
+  width: `fit-content`,
+  height: `fit-content`
+});
+
+const Round = ({ colorStartIndex = 0, duration = DEFAULT_DELAY * 10, delay = 0, roundSize = '6rem' }) => {
+  const [index, addIndex] = useIndex(HUE_MAX_INDEX, colorStartIndex);
+  return (
+    <div
+      css={[roundStyle(getPastelColor(index), duration, roundSize, delay)]}
+      onAnimationIteration={() => {
+        addIndex();
+      }}
+    ></div>
+  );
+};
+
+const LoadingSpinnerWave = ({ delay = DEFAULT_DELAY, roundSize = '2.5rem' }) => {
+  return (
+    <div css={loadingSpinnerWaveStyle}>
+      <Round roundSize={roundSize} duration={delay * 10} />
+      <Round
+        roundSize={roundSize}
+        duration={delay * 10}
+        colorStartIndex={Math.floor((3.5 * HUE_MAX_INDEX) / 4)}
+        delay={delay}
+      />
+      <Round
+        roundSize={roundSize}
+        duration={delay * 10}
+        colorStartIndex={Math.floor((1.5 * HUE_MAX_INDEX) / 4)}
+        delay={delay * 2}
+      />
+      <Round
+        roundSize={roundSize}
+        duration={delay * 10}
+        colorStartIndex={Math.floor((2 * HUE_MAX_INDEX) / 4)}
+        delay={delay * 3}
+      />
+    </div>
+  );
+};
+
+export default LoadingSpinnerWave;

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -2,6 +2,7 @@ import { css, keyframes } from '@emotion/react';
 import CloseIcon from '../../assets/icons/close.svg?react';
 import { useTimeout } from '../../hooks';
 import { Variables } from '../../styles/Variables';
+import { parseNumberAndUnit } from '../../utils';
 
 type Position = {
   bottom?: string;
@@ -16,18 +17,9 @@ type ToastProps = {
   position?: Position;
 };
 
-function parsePosition(position: string | undefined): [number, string] {
-  const regex = /([0-9]+)(.*)/;
-  const matches = position?.match(regex);
-  if (matches) {
-    return [Number(matches[1]), matches[2]];
-  }
-  return [0, ''];
-}
-
 const slideUp = (position: Position) => {
   const { bottom } = position;
-  const [number, unit] = parsePosition(bottom);
+  const [number, unit] = parseNumberAndUnit(bottom);
   return keyframes({
     '0%': {
       opacity: '0',
@@ -42,7 +34,7 @@ const slideUp = (position: Position) => {
 
 const slideDown = (position: Position) => {
   const { bottom } = position;
-  const [number, unit] = parsePosition(bottom);
+  const [number, unit] = parseNumberAndUnit(bottom);
   return keyframes({
     '0%': {
       opacity: '1',

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -59,7 +59,7 @@ const toastCss = css({
   position: 'fixed',
   transform: 'translate(-50%, 0%)',
 
-  width: '21rem',
+  minWidth: '21rem',
   padding: '1.5rem 1rem',
   borderRadius: '0.75rem',
   boxSizing: 'content-box',

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -1,3 +1,4 @@
 export { default as Header } from './Header';
 export { default as Toast } from './Toast';
+export { default as LoadingSpinner } from './LoadingSpinner';
 export { default as LoadingSpinnerWave } from './LoadingSpinnerWave';

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -1,2 +1,3 @@
 export { default as Header } from './Header';
 export { default as Toast } from './Toast';
+export { default as LoadingSpinnerWave } from './LoadingSpinnerWave';

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export { useIndex } from './useIndex';
 export { useTimeout } from './useTimeout';

--- a/frontend/src/hooks/useIndex.ts
+++ b/frontend/src/hooks/useIndex.ts
@@ -1,0 +1,10 @@
+import { useState } from 'react';
+
+export function useIndex(length: number, startIndex: number = 0): [number, Function] {
+  const [index, setIndex] = useState(startIndex % length);
+  function addIndex() {
+    if (index >= length - 1) setIndex(0);
+    else setIndex(index + 1);
+  }
+  return [index, addIndex];
+}

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,10 +1,7 @@
-import { hoverGrowJumpAnimation } from '../styles';
 import { Variables } from '../styles/Variables';
 import { css } from '@emotion/react';
-import { Header, Toast } from '../components/common/';
+import { Header } from '../components/common/';
 import clapImage from '../assets/landing-clap.png';
-import CheckIcon from '../assets/icons/check.svg?react';
-import { useState } from 'react';
 import RoomCreateButton from '../components/RoomCreateButton';
 
 const backgroundStyle = css`
@@ -21,18 +18,10 @@ const backgroundStyle = css`
 const headingTextStyle = css({ font: Variables.typography.font_bold_72, color: Variables.colors.text_default });
 
 const LandingPage = () => {
-  const [toast, setToast] = useState(false);
   return (
     <>
       <Header />
       <div css={backgroundStyle}>
-        {toast && (
-          <Toast
-            icon={() => <CheckIcon css={{ fill: Variables.colors.text_word_weak }} />}
-            text="서버와 통신 중 에러가 발생했습니다!"
-            setToast={setToast}
-          />
-        )}
         <section css={{ display: 'flex', alignItems: 'center', margin: 'auto 0', gap: 100 }}>
           <div css={{ display: 'flex', flexDirection: 'column', gap: 66 }}>
             <h1 css={headingTextStyle}>

--- a/frontend/src/pages/LoadingPage.tsx
+++ b/frontend/src/pages/LoadingPage.tsx
@@ -1,0 +1,29 @@
+import { css } from '@emotion/react';
+import { LoadingSpinnerWave } from '../components/common';
+import { Variables } from '../styles/Variables';
+
+const loadingPageStyle = css({
+  width: '100vw',
+  height: '100vh',
+
+  display: 'flex',
+  gap: '2rem',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center'
+});
+
+const LoadingPage = () => {
+  return (
+    <div css={loadingPageStyle}>
+      <div css={{ position: 'relative' }}>
+        <LoadingSpinnerWave />
+      </div>
+      <p css={{ font: Variables.typography.font_medium_16, color: Variables.colors.text_alt }}>
+        관심사를 나누러 가는 중...
+      </p>
+    </div>
+  );
+};
+
+export default LoadingPage;

--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -9,6 +9,7 @@ import useParticipantsStore from '../../stores/participants';
 import { Variables } from '../../styles/Variables';
 import { css } from '@emotion/react';
 import ParticipantListSidebar from '../../components/ParticipantListSidebar';
+import { ShareButton } from '../../components';
 // import { Header } from '../../components/common';
 
 const backgroundStyle = css`
@@ -75,7 +76,7 @@ const Room = () => {
           ))}
         </div>
         {isHost ? <HostView participantCount={participants.length} /> : <ParticipantView />}
-        <button>링크로 복사하기</button>
+        <ShareButton />
       </div>
       <ParticipantListSidebar />
     </>

--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -10,6 +10,7 @@ import { Variables } from '../../styles/Variables';
 import { css } from '@emotion/react';
 import ParticipantListSidebar from '../../components/ParticipantListSidebar';
 import { ShareButton } from '../../components';
+import LoadingPage from '../LoadingPage';
 // import { Header } from '../../components/common';
 
 const backgroundStyle = css`
@@ -34,6 +35,7 @@ const Room = () => {
   const [roomExists, setRoomExists] = useState(true);
   const { participants, setParticipants } = useParticipantsStore();
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (socket && roomId) {
@@ -44,6 +46,7 @@ const Room = () => {
           setRoomExists(response.status === 'ok' ? true : false);
           setParticipants(response.body.participants);
           setIsHost(response.body.hostFlag);
+          setLoading(false);
           if (socket.id) setCurrentUserId(socket.id);
         }
       );
@@ -64,21 +67,27 @@ const Room = () => {
   return (
     <>
       {/* <Header /> */}
-      <div css={backgroundStyle}>
-        <div
-          css={css`
-            display: flex;
-            margin-bottom: ${Variables.spacing.spacing_lg};
-          `}
-        >
-          {participants.map((participant, index) => (
-            <UserProfile participant={participant} index={index} isCurrentUser={participant.id === currentUserId} />
-          ))}
-        </div>
-        {isHost ? <HostView participantCount={participants.length} /> : <ParticipantView />}
-        <ShareButton />
-      </div>
-      <ParticipantListSidebar />
+      {loading ? (
+        <LoadingPage />
+      ) : (
+        <>
+          <div css={backgroundStyle}>
+            <div
+              css={css`
+                display: flex;
+                margin-bottom: ${Variables.spacing.spacing_lg};
+              `}
+            >
+              {participants.map((participant, index) => (
+                <UserProfile participant={participant} index={index} isCurrentUser={participant.id === currentUserId} />
+              ))}
+            </div>
+            {isHost ? <HostView participantCount={participants.length} /> : <ParticipantView />}
+            <ShareButton />
+          </div>
+          <ParticipantListSidebar />
+        </>
+      )}
     </>
   );
 };

--- a/frontend/src/styles/animation.ts
+++ b/frontend/src/styles/animation.ts
@@ -13,6 +13,21 @@ export const jump = (baseTransform: string, height: string = '0.7rem') =>
     }
   });
 
+export const growAndShrink = keyframes({
+  '0%': {
+    transform: 'scale(0)'
+  },
+  '2%': {
+    transform: 'scale(0)'
+  },
+  '49%': {
+    transform: 'scale(1)'
+  },
+  '51%': {
+    transform: 'scale(1)'
+  }
+});
+
 export const hoverGrow = (scale: number = 1.035) =>
   css({
     transition: 'transform 0.2s ease-in-out',

--- a/frontend/src/styles/animation.ts
+++ b/frontend/src/styles/animation.ts
@@ -1,5 +1,14 @@
 import { css, keyframes } from '@emotion/react';
 
+export const rotate = keyframes({
+  '0%': {
+    transform: 'rotate(0)'
+  },
+  '100%': {
+    transform: 'rotate(360deg)'
+  }
+});
+
 export const jump = (baseTransform: string, height: string = '0.7rem') =>
   keyframes({
     '0%': {

--- a/frontend/src/styles/index.ts
+++ b/frontend/src/styles/index.ts
@@ -1,1 +1,1 @@
-export { hoverGrowJumpAnimation } from './animation';
+export { growAndShrink, hoverGrowJumpAnimation } from './animation';

--- a/frontend/src/styles/index.ts
+++ b/frontend/src/styles/index.ts
@@ -1,1 +1,1 @@
-export { growAndShrink, hoverGrowJumpAnimation } from './animation';
+export { rotate, growAndShrink, hoverGrowJumpAnimation } from './animation';

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,0 +1,1 @@
+export { parseNumberAndUnit } from './parseNumberAndUnit';

--- a/frontend/src/utils/parseNumberAndUnit.ts
+++ b/frontend/src/utils/parseNumberAndUnit.ts
@@ -1,0 +1,8 @@
+export function parseNumberAndUnit(numberAndUnit: string | undefined): [number, string] {
+  const regex = /([0-9\.]+)(.*)/;
+  const matches = numberAndUnit?.match(regex);
+  if (matches) {
+    return [Number(matches[1]), matches[2]];
+  }
+  return [0, ''];
+}


### PR DESCRIPTION
close #11

# ✅ 주요 작업
- [x] 로딩 구현  #11
  - [x] 로딩 스피너(웨이브형, 원형) 구현
  - [x] 로딩 페이지 구현
  - [x] 시작 버튼 및 방 입장에 로딩 적용

## 작업 결과
### 3g 스로틀링
![로딩적용_large](https://github.com/user-attachments/assets/d354912e-0160-4cc3-9321-6e6e08e3de66)
로딩을 확인하기 위해 3g로 스로틀링을 준 예시 실행화면입니다.

### 4g_slow 스로틀링
![로딩적용_4g_slow_large](https://github.com/user-attachments/assets/7250d96b-e926-4d16-94ed-b397399ddd4b)
로딩을 확인하기 위해 4g_slow 로 스로틀링을 준 예시 실행화면입니다.

# 📚 학습 키워드
`animation`, `로딩 스피너`

# 💭 고민과 해결과정
### 웨이브형 로딩 스피너
- 색상이 고정된 편보단 계속 변하는 편이 사용자 입장에서 지루함을 덜 느낄 것이라고 생각해서 `onAnimationIteration`을 활용해 애니메이션이 반복될 때마다 색이 변경되도록 구현하였습니다. 파스텔톤을 유지하면서 색상만 변하도록 `hsla`를 사용해 색상을 반환하는 함수를 구현하였습니다.
- 각 원들이 작아졌다가 커지는 흐름이 자연스럽도록 duration과 delay를 조정해봤고, 결과적으로 duration은 `delay * 10`일 때, delay는 각각 `0, delay, 2 * delay, 3 * delay` 일 때 가장 자연스럽다는 걸 확인해 적용하였습니다.
- delay와 roundSize를 props로 줄 수 있는데, 주지 않을 경우 기본값이 적용됩니다. 만약 외부에서 커스텀해서 사용하고 싶다면 해당 두 값을 props로 줄 수 있습니다.

### 원형 로딩 스피너
- 외부에서 커스텀해서 사용할 수 있도록 roundSize, width, emptyColor, fillColor, speed를 각각 props로 받습니다. 만약 주어지지 않을 경우 기본값(크기는 작게, 색은 회색 계열)이 적용됩니다.
  - `width`의 경우, 개인적으로 `roundSize/6.5`가 가장 적당한 두께로 보여서 해당 계산식을 적용하도록 구현했습니다. 따라서 기본적으로 width는 커스텀하지 않아도 됩니다, 만약 해당 계산식으로 인한 결과가 만족스럽지 않을 경우에만 값을 추가하는 걸 추천합니다!
    ```ts
    <LoadingSpinner
      roundSize="1.7rem"
      emptyColor={`${Variables.colors.surface_white}50`}
      fillColor={Variables.colors.surface_white}
    />
    ```
      - 커스텀 사용 예제입니다.

# 📌 이슈 사항
X