### PR TITLE
flex wrapper 재사용 스타일 추가, 질문을 표시할 QuestionView 구현, Header 컴포넌트에 paddingY prop 추가

### DIFF
--- a/frontend/src/components/ParticipantListSidebar.tsx
+++ b/frontend/src/components/ParticipantListSidebar.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { useState } from 'react';
-import { Variables } from '../styles/Variables';
+import { Variables } from '../styles';
 import Modal from './common/Modal';
 
 const ListContainerStyle = css`

--- a/frontend/src/components/QuestionStartButton.tsx
+++ b/frontend/src/components/QuestionStartButton.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
-import { Variables } from '../styles/Variables';
+import { Variables } from '../styles';
+import useSocket from '../hooks/useSocket';
 
 const ButtonStyle = css({
   backgroundColor: Variables.colors.surface_black,
@@ -10,7 +11,19 @@ const ButtonStyle = css({
 });
 
 const QuestionStartButton = () => {
-  return <button css={ButtonStyle}>추억 모으기 시작하기 🚀</button>;
+  const socket = useSocket();
+
+  const onClickStart = () => {
+    if (socket) {
+      socket.emit('participant:host:start');
+    }
+  };
+
+  return (
+    <button css={ButtonStyle} onClick={onClickStart}>
+      추억 모으기 시작하기 🚀
+    </button>
+  );
 };
 
 export default QuestionStartButton;

--- a/frontend/src/components/QuestionStartButton.tsx
+++ b/frontend/src/components/QuestionStartButton.tsx
@@ -1,0 +1,16 @@
+import { css } from '@emotion/react';
+import { Variables } from '../styles/Variables';
+
+const ButtonStyle = css({
+  backgroundColor: Variables.colors.surface_black,
+  color: Variables.colors.text_white,
+  font: Variables.typography.font_bold_24,
+  borderRadius: '999px',
+  padding: '16px 144px'
+});
+
+const QuestionStartButton = () => {
+  return <button css={ButtonStyle}>추억 모으기 시작하기 🚀</button>;
+};
+
+export default QuestionStartButton;

--- a/frontend/src/components/RoomCreateButton.tsx
+++ b/frontend/src/components/RoomCreateButton.tsx
@@ -1,6 +1,6 @@
 import { hoverGrowJumpAnimation } from '../styles';
 import { useNavigate } from 'react-router-dom';
-import { Variables } from '../styles/Variables';
+import { Variables } from '../styles';
 import { css } from '@emotion/react';
 import { useState } from 'react';
 import { LoadingSpinner, Toast } from './common';

--- a/frontend/src/components/RoomNotFound.tsx
+++ b/frontend/src/components/RoomNotFound.tsx
@@ -1,5 +1,5 @@
 import { useNavigate } from 'react-router-dom';
-import { Variables } from '../styles/Variables';
+import { Variables } from '../styles';
 import { css } from '@emotion/react';
 
 const backgroundStyle = css`

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { Variables } from '../styles/Variables';
+import { Variables } from '../styles';
 import { useState } from 'react';
 import { Toast } from './common';
 import { hoverGrowJumpAnimation } from '../styles';

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -1,4 +1,4 @@
-import { Variables } from '../styles/Variables';
+import { Variables } from '../styles';
 import { css } from '@emotion/react';
 
 const profileStyle = css`

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -11,16 +11,17 @@ const headerWrapperStyle = css({
   padding: 24
 });
 
-const headerStyle = css({
-  backgroundColor: Variables.colors.surface_white,
-  width: '100%',
-  borderRadius: 999,
-  display: 'flex',
-  justifyContent: 'space-between',
-  padding: '24px 32px',
-  alignItems: 'center',
-  boxShadow: '0 0 30px #00000008'
-});
+const headerStyle = (paddingY: number) =>
+  css({
+    backgroundColor: Variables.colors.surface_white,
+    width: '100%',
+    borderRadius: 999,
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: `${paddingY}px 32px`,
+    alignItems: 'center',
+    boxShadow: '0 0 30px #00000008'
+  });
 
 const navStyle = css({
   display: 'flex',
@@ -29,10 +30,14 @@ const navStyle = css({
   font: Variables.typography.font_medium_20
 });
 
-const Header = () => {
+interface HeaderProps {
+  paddingY?: number;
+}
+
+const Header = ({ paddingY = 24 }: HeaderProps) => {
   return (
     <header css={headerWrapperStyle}>
-      <div css={headerStyle}>
+      <div css={headerStyle(paddingY)}>
         <a css={{ font: Variables.typography.font_bold_24 }} href="/">
           친해지길
         </a>

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,4 +1,4 @@
-import { Variables } from '../styles/Variables';
+import { Variables } from '../styles';
 import { css } from '@emotion/react';
 import { Header } from '../components/common/';
 import clapImage from '../assets/landing-clap.png';

--- a/frontend/src/pages/LoadingPage.tsx
+++ b/frontend/src/pages/LoadingPage.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import { LoadingSpinnerWave } from '../components/common';
-import { Variables } from '../styles/Variables';
+import { Variables } from '../styles';
 
 const loadingPageStyle = css({
   width: '100vw',

--- a/frontend/src/pages/room/hostView.tsx
+++ b/frontend/src/pages/room/hostView.tsx
@@ -1,5 +1,5 @@
 import QuestionStartButton from '../../components/QuestionStartButton';
-import { flexStyle } from '../../styles/flex';
+import { flexStyle } from '../../styles';
 import { Variables } from '../../styles/Variables';
 import { css } from '@emotion/react';
 

--- a/frontend/src/pages/room/hostView.tsx
+++ b/frontend/src/pages/room/hostView.tsx
@@ -1,3 +1,5 @@
+import QuestionStartButton from '../../components/QuestionStartButton';
+import { flexStyle } from '../../styles/flex';
 import { Variables } from '../../styles/Variables';
 import { css } from '@emotion/react';
 
@@ -14,10 +16,13 @@ const HostView = ({ participantCount }: HostViewProps) => {
   return (
     <div>
       {participantCount > 1 ? (
-        <p css={InstructionStyle}>
-          방에 참가자들이
-          <br /> 다 모였다면 시작해볼까요?
-        </p>
+        <div css={flexStyle(48, 'column')}>
+          <p css={InstructionStyle}>
+            방에 참가자들이
+            <br /> 다 모였다면 시작해볼까요?
+          </p>
+          <QuestionStartButton />
+        </div>
       ) : (
         <div>
           <p css={InstructionStyle}>

--- a/frontend/src/pages/room/questionsView.tsx
+++ b/frontend/src/pages/room/questionsView.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from 'react';
+import useSocket from '../../hooks/useSocket';
+import useQuestionsStore from '../../stores/questions';
+
+interface QuestionViewProps {
+  onQuestionStart: () => void; // 질문이 표시될 때 인트로를 숨김
+}
+
+const QuestionsView = ({ onQuestionStart }: QuestionViewProps) => {
+  const socket = useSocket();
+  const { questions, setQuestions } = useQuestionsStore();
+
+  useEffect(() => {
+    if (socket) {
+      // socket.on('empathy:start', (questions: { questions: Question[] }) => {
+      //   setQuestions((prev) => [
+      //     ...prev,
+      //     {
+      //       id: '1',
+      //       title: '좋아하는 취미는?',
+      //       expirationTime: (Date.now() + 1000 * 30).toString()
+      //     },
+      //     {
+      //       id: '2',
+      //       title: '좋아하는 음식은?',
+      //       expirationTime: (Date.now() + 1000 * 30).toString()
+      //     }
+      //   ]);
+      // });
+
+      setQuestions((prev) => [
+        ...prev,
+        {
+          id: '1',
+          title: '좋아하는 취미는?',
+          expirationTime: (Date.now() + 1000 * 30).toString()
+        },
+        {
+          id: '2',
+          title: '좋아하는 음식은?',
+          expirationTime: (Date.now() + 1000 * 60).toString()
+        }
+      ]);
+
+      // onQuestionStart();
+    }
+  }, [socket, setQuestions]);
+
+  return (
+    <div>
+      <h1>QuestionView</h1>
+      {questions.map((question) => (
+        <>
+          <ul key={question.id}>
+            <li>{question.title}</li>
+            <li>{question.expirationTime}</li>
+          </ul>
+        </>
+      ))}
+    </div>
+  );
+};
+
+// get
+export default QuestionsView;

--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -11,6 +11,7 @@ import { css } from '@emotion/react';
 import ParticipantListSidebar from '../../components/ParticipantListSidebar';
 import { ShareButton } from '../../components';
 import LoadingPage from '../LoadingPage';
+import QuestionsView from './questionsView';
 // import { Header } from '../../components/common';
 
 const backgroundStyle = css`
@@ -36,6 +37,9 @@ const Room = () => {
   const { participants, setParticipants } = useParticipantsStore();
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isIntroViewActive, setIsIntroViewActive] = useState(true);
+
+  const hideIntroView = () => setIsIntroViewActive(false);
 
   useEffect(() => {
     if (socket && roomId) {
@@ -82,7 +86,8 @@ const Room = () => {
                 <UserProfile participant={participant} index={index} isCurrentUser={participant.id === currentUserId} />
               ))}
             </div>
-            {isHost ? <HostView participantCount={participants.length} /> : <ParticipantView />}
+            {isIntroViewActive && (isHost ? <HostView participantCount={participants.length} /> : <ParticipantView />)}
+            <QuestionsView onQuestionStart={hideIntroView} />
             <ShareButton />
           </div>
           <ParticipantListSidebar />

--- a/frontend/src/stores/questions.ts
+++ b/frontend/src/stores/questions.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import { Question } from '../types';
+
+interface QuestionsStore {
+  questions: Question[];
+  setQuestions: (newQuestions: Question[] | ((prev: Question[]) => Question[])) => void;
+}
+
+const useQuestionsStore = create<QuestionsStore>((set) => ({
+  questions: [],
+  setQuestions: (newQuestions) =>
+    set((state) => ({
+      questions: typeof newQuestions === 'function' ? newQuestions(state.questions) : newQuestions
+    }))
+}));
+
+export default useQuestionsStore;

--- a/frontend/src/styles/flex.ts
+++ b/frontend/src/styles/flex.ts
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+import type { Properties } from 'csstype';
+
+export const flexStyle = (
+  gap: number,
+  flexDirection: Properties['flexDirection'] = 'row',
+  justifyContent: Properties['justifyContent'] = 'center',
+  alignItems: Properties['alignItems'] = 'center'
+) => {
+  return css({
+    display: 'flex',
+    flexDirection,
+    justifyContent,
+    alignItems,
+    gap: `${gap}px`
+  });
+};

--- a/frontend/src/styles/index.ts
+++ b/frontend/src/styles/index.ts
@@ -1,1 +1,3 @@
 export { rotate, growAndShrink, hoverGrowJumpAnimation } from './animation';
+export { flexStyle } from './flex';
+export { Variables } from './Variables';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,1 @@
+export type { Question } from './question';

--- a/frontend/src/types/question.ts
+++ b/frontend/src/types/question.ts
@@ -1,0 +1,5 @@
+export interface Question {
+  id: string;
+  title: string;
+  expirationTime: string;
+}


### PR DESCRIPTION
# ✅ 주요 작업
- 요소들을 Flex 래퍼로 감싸기 편하게 `flexStyle`을 추가했습니다.
- Header의 높이조절을 위해 paddingY prop을 추가했습니다
- QuestionView 관련 스켈레톤 코드를 작성했습니다

금요일, 주말까지 가능하면 2주차의 질문별 타이머 동작 기능 구현을 해보겠습니다

# 📚 학습 키워드
zustand, socket.io

# 💭 고민과 해결과정
- 모두에게 동일하게 표시될 질문 리스트를 전역 상태로 두었습니다. 추후 만료시간 증가 등이 가능할 것 같습니다.
- QuestionView에 콜백함수를 전달해서 질문이 시작되면 기존의 안내문구를 포함한 view를 숨김 처리할 수 있도록 했습니다. (지금은 주석으로 비활성화 해뒀습니다)
- css 프로퍼티 `Properties` 타입을 활용해서 요소들을 Flex 래퍼로 감싸기 편하게 `flexStyle`을 추가했습니다.
```ts
import { css } from '@emotion/react';
import type { Properties } from 'csstype';

export const flexStyle = (
  gap: number,
  flexDirection: Properties['flexDirection'] = 'row',
  justifyContent: Properties['justifyContent'] = 'center',
  alignItems: Properties['alignItems'] = 'center'
) => {
  return css({
    display: 'flex',
    flexDirection,
    justifyContent,
    alignItems,
    gap: `${gap}px`
  });
};
```

# 📌 이슈 사항
- 질문 리스트를 전달하는 API를 포함한 서버 코드에서 방 개설 API에도 변경이 있었는데 제 브랜치의 FE 코드에선 수정사항 반영이 안 되어 있어서 방장 페이지의 시작 버튼을 표시할 수 없었습니다. 그래서 일단 mock 데이터로 스켈레톤 코드만 작성하였습니다. 