### PR TITLE
chore: 🤖 SOCKET_SERVER_URL env 설정

### DIFF
--- a/frontend/src/components/RoomCreateButton.tsx
+++ b/frontend/src/components/RoomCreateButton.tsx
@@ -4,6 +4,7 @@ import { Variables } from '../styles';
 import { css } from '@emotion/react';
 import { useState } from 'react';
 import { LoadingSpinner, Toast } from './common';
+import { config } from '../config';
 import CheckIcon from '../assets/icons/check.svg?react';
 
 const startButtonStyle = css(
@@ -30,7 +31,7 @@ const RoomCreateButton = () => {
   const createRoom = async () => {
     try {
       setLoading(true);
-      const response = await fetch('http://localhost:8080/rooms', {
+      const response = await fetch(`${config.SOCKET_SERVER_URL}/rooms`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -1,0 +1,4 @@
+export const config = {
+    SOCKET_SERVER_URL: import.meta.env.VITE_SOCKET_SERVER_URL,
+  };
+  

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -1,7 +1,6 @@
 import { useEffect, useState } from 'react';
 import { Socket, io } from 'socket.io-client';
-
-const SOCKET_SERVER_URL = 'http://localhost:8080';
+import { config } from '../config';
 
 export const useSocket = () => {
   // socket 유지를 위해 state에 socket 인스턴스를 담아서 사용
@@ -9,7 +8,7 @@ export const useSocket = () => {
 
   useEffect(() => {
     // 소켓 연결
-    const socketInstance = io(SOCKET_SERVER_URL);
+    const socketInstance = io(config.SOCKET_SERVER_URL);
     setSocket(socketInstance);
 
     return () => {


### PR DESCRIPTION
# ✅ 주요 작업
SOCKET_SERVER_URL 환경변수 설정
> 작업 결과를 눈으로 확인할 수 있는 스크린샷 등이 있다면 첨부해주세요

# 📚 학습 키워드
vite 환경에서 env 설정하기

# 💭 고민과 해결과정
VITE환경에서 환경설정 파일을 생성하는 방식은 기존 CRA방식과 조금 달랐습니다.
1. .env 파일 설정(루트 디렉토리에 .env파일 추가)
```
VITE_SOCKET_SERVER_URL=http://localhost:8080
```
VITE_ 접두사를 붙여서 정의해야만 Vite가 이 변수를 프론트엔드 코드에서 인식할 수 있습니다.

2. 환경 변수 사용
process.env.SOCKET_SERVER_URL 대신 **import.meta.env.VITE_SOCKET_SERVER_URL**을 사용하면 됩니다.

import.meta.env에서 변수를 불러오는 방식이 지저분하게 느껴져 별도의 config.ts 파일을 만들었습니다.
```ts
export const config = {
    SOCKET_SERVER_URL: import.meta.env.VITE_SOCKET_SERVER_URL,
  };
 ```
# 📌 이슈 사항
