### PR TITLE
참여자 UI 타원 배치, 참여자 리스트 Profile item 추가

### DIFF
--- a/frontend/src/assets/icons/profile.svg
+++ b/frontend/src/assets/icons/profile.svg
@@ -1,0 +1,12 @@
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Transformed by: SVG Repo Mixer Tools -->
+<svg width="40px" height="40px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+
+<g id="SVGRepo_bgCarrier" stroke-width="0"/>
+
+<g id="SVGRepo_tracerCarrier" stroke-linecap="round" stroke-linejoin="round"/>
+
+<g id="SVGRepo_iconCarrier"> <path opacity="0.4" d="M12 22.01C17.5228 22.01 22 17.5329 22 12.01C22 6.48716 17.5228 2.01001 12 2.01001C6.47715 2.01001 2 6.48716 2 12.01C2 17.5329 6.47715 22.01 12 22.01Z" fill="#87898c"/> <path d="M12 6.93994C9.93 6.93994 8.25 8.61994 8.25 10.6899C8.25 12.7199 9.84 14.3699 11.95 14.4299C11.98 14.4299 12.02 14.4299 12.04 14.4299C12.06 14.4299 12.09 14.4299 12.11 14.4299C12.12 14.4299 12.13 14.4299 12.13 14.4299C14.15 14.3599 15.74 12.7199 15.75 10.6899C15.75 8.61994 14.07 6.93994 12 6.93994Z" fill="#87898c"/> <path d="M18.7807 19.36C17.0007 21 14.6207 22.01 12.0007 22.01C9.3807 22.01 7.0007 21 5.2207 19.36C5.4607 18.45 6.1107 17.62 7.0607 16.98C9.7907 15.16 14.2307 15.16 16.9407 16.98C17.9007 17.62 18.5407 18.45 18.7807 19.36Z" fill="#87898c"/> </g>
+
+</svg>

--- a/frontend/src/components/ParticipantListSidebar.tsx
+++ b/frontend/src/components/ParticipantListSidebar.tsx
@@ -4,8 +4,15 @@ import { useState } from 'react';
 import { Variables } from '@/styles';
 
 import Modal from './common/Modal';
+import { useParticipantsStore } from '@/stores';
+
+import Profile from '@/assets/icons/profile.svg?react';
 
 const ListContainerStyle = css`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 8px;
   width: 200px;
   height: 95%;
 `;
@@ -22,8 +29,18 @@ const SidebarTriggerArea = css`
   }
 `;
 
+const ParticipantItemStyle = css`
+  display: flex;
+  gap: 7px;
+  align-items: center;
+  span {
+    font: ${Variables.typography.font_medium_16};
+  }
+`;
+
 const ParticipantListSidebar = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const { participants } = useParticipantsStore();
 
   return (
     <div>
@@ -33,7 +50,15 @@ const ParticipantListSidebar = () => {
         onMouseLeave={() => setIsModalOpen(false)}
       />
       <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
-        <div css={ListContainerStyle}>참여자 리스트</div>
+        <div css={ListContainerStyle}>
+          <div>참여자 리스트</div>
+          {participants.map((participant) => (
+            <div key={participant.id} css={ParticipantItemStyle}>
+              <Profile/>
+              <span>{participant.nickname}</span>
+            </div>
+          ))}
+        </div>
       </Modal>
     </div>
   );

--- a/frontend/src/components/QuestionStartButton.tsx
+++ b/frontend/src/components/QuestionStartButton.tsx
@@ -6,9 +6,9 @@ import { Variables } from '@/styles';
 const ButtonStyle = css({
   backgroundColor: Variables.colors.surface_black,
   color: Variables.colors.text_white,
-  font: Variables.typography.font_bold_24,
+  font: Variables.typography.font_bold_20,
   borderRadius: '999px',
-  padding: '16px 144px'
+  padding: '16px 80px'
 });
 
 const QuestionStartButton = () => {
@@ -22,7 +22,7 @@ const QuestionStartButton = () => {
 
   return (
     <button css={ButtonStyle} onClick={onClickStart}>
-      추억 모으기 시작하기 🚀
+      관심사로 소통 시작하기 🚀
     </button>
   );
 };

--- a/frontend/src/components/QuestionStartButton.tsx
+++ b/frontend/src/components/QuestionStartButton.tsx
@@ -6,9 +6,9 @@ import { Variables } from '@/styles';
 const ButtonStyle = css({
   backgroundColor: Variables.colors.surface_black,
   color: Variables.colors.text_white,
-  font: Variables.typography.font_bold_20,
+  font: Variables.typography.font_bold_16,
   borderRadius: '999px',
-  padding: '16px 80px'
+  padding: '12px 50px'
 });
 
 const QuestionStartButton = () => {

--- a/frontend/src/components/RoomCreateButton.tsx
+++ b/frontend/src/components/RoomCreateButton.tsx
@@ -10,13 +10,12 @@ import { LoadingSpinner, Toast } from './common';
 
 const startButtonStyle = css(
   {
-    font: Variables.typography.font_bold_24,
+    font: Variables.typography.font_bold_20,
     color: Variables.colors.text_white,
     backgroundColor: Variables.colors.surface_point,
-    padding: '24px 48px',
-    borderRadius: 32,
+    borderRadius: 999,
     minWidth: '23.6rem',
-    minHeight: '5.1875rem',
+    minHeight: '3.5rem',
     ':hover': {
       opacity: 0.8
     }

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -4,10 +4,10 @@ import Crown from '@/assets/icons/crown.svg?react';
 import { useRadiusStore } from '@/stores';
 import { Variables } from '@/styles';
 
-const profileStyle = (x: number, y: number, radius: number) => css`
+const profileStyle = (x: number, y: number, shortRadius: number, longRadius: number) => css`
   position: absolute;
-  left: ${radius + x}px;
-  bottom: ${radius + y}px;
+  left: ${longRadius + x}px;
+  bottom: ${shortRadius + y}px;
   transform: translate(-50%, 50%);
   transition: 1s ease-in-out;
 `;
@@ -87,7 +87,7 @@ const UserProfile = ({ participant, index, isCurrentUser, isHost, position }: Us
   const { radius } = useRadiusStore();
 
   return (
-    <div key={participant.id} css={profileStyle(position.x, position.y, radius)}>
+    <div key={participant.id} css={profileStyle(position.x, position.y, radius[0], radius[1])}>
       <div css={profileImageStyle(profileColors[index % profileColors.length])}>
         {isHost && (
           <div css={hostStyle}>

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -21,7 +21,7 @@ const headerStyle = (paddingY: number) =>
     justifyContent: 'space-between',
     padding: `${paddingY}px 32px`,
     alignItems: 'center',
-    boxShadow: '0 0 30px #00000008'
+    boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)'
   });
 
 const navStyle = css({
@@ -35,7 +35,7 @@ interface HeaderProps {
   paddingY?: number;
 }
 
-const Header = ({ paddingY = 18 }: HeaderProps) => {
+const Header = ({ paddingY = 17 }: HeaderProps) => {
   return (
     <header css={headerWrapperStyle}>
       <div css={headerStyle(paddingY)}>

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -27,15 +27,15 @@ const headerStyle = (paddingY: number) =>
 const navStyle = css({
   display: 'flex',
   gap: 24,
-  color: Variables.colors.text_weak,
-  font: Variables.typography.font_medium_20
+  color: Variables.colors.text_default,
+  font: Variables.typography.font_medium_16
 });
 
 interface HeaderProps {
   paddingY?: number;
 }
 
-const Header = ({ paddingY = 24 }: HeaderProps) => {
+const Header = ({ paddingY = 18 }: HeaderProps) => {
   return (
     <header css={headerWrapperStyle}>
       <div css={headerStyle(paddingY)}>

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,2 +1,4 @@
-export const MIN_RADIUS = 220; //반지름
-export const MAX_RADIUS = 260;
+export const MIN_SHORT_RADIUS = 210; //반지름
+export const MIN_LONG_RADIUS = Math.floor((MIN_SHORT_RADIUS * 4) / 3); //장축:단축 = 4:3
+export const MAX_SHORT_RADIUS = 240;
+export const MAX_LONG_RADIUS = Math.floor((MAX_SHORT_RADIUS * 4) / 3);

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -17,7 +17,7 @@ const backgroundStyle = css`
   align-items: center;
 `;
 
-const headingTextStyle = css({ font: Variables.typography.font_bold_72, color: Variables.colors.text_default });
+const headingTextStyle = css({ font: Variables.typography.font_bold_56, color: Variables.colors.text_default });
 
 const LandingPage = () => {
   return (
@@ -25,7 +25,7 @@ const LandingPage = () => {
       <Header />
       <div css={backgroundStyle}>
         <section css={{ display: 'flex', alignItems: 'center', margin: 'auto 0', gap: 100 }}>
-          <div css={{ display: 'flex', flexDirection: 'column', gap: 66 }}>
+          <div css={{ display: 'flex', flexDirection: 'column', gap: 40 }}>
             <h1 css={headingTextStyle}>
               간편하게
               <br />

--- a/frontend/src/pages/room/hostView.tsx
+++ b/frontend/src/pages/room/hostView.tsx
@@ -18,7 +18,7 @@ const HostView = ({ participantCount }: HostViewProps) => {
   return (
     <div>
       {participantCount > 1 ? (
-        <div css={flexStyle(48, 'column')}>
+        <div css={flexStyle(30, 'column')}>
           <p css={InstructionStyle}>
             방에 참가자들이
             <br /> 다 모였다면 시작해볼까요?

--- a/frontend/src/pages/room/questionsView.tsx
+++ b/frontend/src/pages/room/questionsView.tsx
@@ -8,7 +8,8 @@ import { Question } from '@/types';
 import { getRemainingSeconds } from '@/utils';
 
 const questionTitleStyle = css({
-  font: Variables.typography.font_bold_36
+  font: Variables.typography.font_bold_32,
+  marginBottom: Variables.spacing.spacing_sm
 });
 
 const progressWrapperStyle = css([
@@ -20,21 +21,21 @@ const progressWrapperStyle = css([
 
 const progressBarStyle = css`
   width: 100%;
-  height: 15px;
+  height: 12px;
   border-radius: 50px;
   background-color: #eee;
 
   ::-webkit-progress-bar {
     background-color: ${Variables.colors.surface_alt};
     border-radius: 50px;
-    height: 15px;
+    height: 12px;
     overflow: hidden;
   }
 
   ::-webkit-progress-value {
     background-color: ${Variables.colors.surface_strong};
     border-radius: 50px;
-    height: 15px;
+    height: 12px;
   }
 `;
 
@@ -92,7 +93,7 @@ const QuestionsView = ({ onQuestionStart }: QuestionViewProps) => {
     <div>
       <h1 css={questionTitleStyle}>{`Q${currentQuestionIndex + 1}. ${questions[currentQuestionIndex].title}`}</h1>
       <div css={progressWrapperStyle}>
-        <ClockIcon width="40px" height="40px" fill="#000" />
+        <ClockIcon width="35px" height="35px" fill="#000" />
         <progress
           id="progress"
           value={initialTimeLeft > 0 ? (timeLeft / initialTimeLeft) * 100 : 100}

--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -26,17 +26,17 @@ const backgroundStyle = css`
   flex-direction: column;
 `;
 
-const ParticipantsContainer = (radius: number) => css`
+const ParticipantsContainer = (shortRadius: number, longRadius: number) => css`
   position: relative;
-  width: ${radius * 2}px;
-  height: ${radius * 2}px;
+  width: ${longRadius * 2}px;
+  height: ${shortRadius * 2}px;
   border-radius: 50%;
 `;
 
-const SubjectContainer = (radius: number) => css`
+const SubjectContainer = (shortRadius: number, longRadius: number) => css`
   position: absolute;
-  bottom: ${radius}px;
-  left: ${radius}px;
+  bottom: ${shortRadius}px;
+  left: ${longRadius}px;
   transform: translate(-50%, 20%);
   white-space: nowrap;
 `;
@@ -58,7 +58,7 @@ const Room = () => {
   const [loading, setLoading] = useState(true);
   const [isIntroViewActive, setIsIntroViewActive] = useState(true);
 
-  const positions = useMemo(() => calculatePosition(participants.length, radius), [radius, participants]);
+  const positions = useMemo(() => calculatePosition(participants.length, radius[0], radius[1]), [radius, participants]);
 
   const hideIntroView = () => setIsIntroViewActive(false);
 
@@ -118,7 +118,7 @@ const Room = () => {
       ) : (
         <>
           <div css={backgroundStyle}>
-            <div css={ParticipantsContainer(radius)}>
+            <div css={ParticipantsContainer(radius[0], radius[1])}>
               {participants.map((participant, index) => (
                 <UserProfile
                   key={participant.id}
@@ -129,7 +129,7 @@ const Room = () => {
                   position={{ x: positions[index][0], y: positions[index][1] }}
                 />
               ))}
-              <div css={SubjectContainer(radius)}>
+              <div css={SubjectContainer(radius[0], radius[1])}>
                 {isIntroViewActive &&
                   (hostId === currentUserId ? (
                     <HostView participantCount={participants.length} />

--- a/frontend/src/stores/radius.ts
+++ b/frontend/src/stores/radius.ts
@@ -1,13 +1,13 @@
 import { create } from 'zustand';
 
-import { MIN_RADIUS, MAX_RADIUS } from '@/constants';
+import { MIN_SHORT_RADIUS, MIN_LONG_RADIUS, MAX_SHORT_RADIUS, MAX_LONG_RADIUS } from '@/constants';
 
 interface RadiusStore {
-  radius: number;
+  radius: [number, number];
   increaseRadius: () => void;
 }
 
 export const useRadiusStore = create<RadiusStore>((set) => ({
-  radius: MIN_RADIUS,
-  increaseRadius: () => set({ radius: MAX_RADIUS })
+  radius: [MIN_SHORT_RADIUS, MIN_LONG_RADIUS],
+  increaseRadius: () => set({ radius: [MAX_SHORT_RADIUS, MAX_LONG_RADIUS] })
 }));

--- a/frontend/src/styles/Variables.ts
+++ b/frontend/src/styles/Variables.ts
@@ -41,6 +41,7 @@ export const Variables = {
     font_bold_56: '700 56px "Pretendard-Variable", sans-serif',
     font_bold_48: '700 48px "Pretendard-Variable", sans-serif',
     font_bold_36: '700 36px "Pretendard-Variable", sans-serif',
+    font_bold_32: '700 32px "Pretendard-Variable", sans-serif',
     font_bold_24: '700 24px "Pretendard-Variable", sans-serif',
     font_bold_20: '700 20px "Pretendard-Variable", sans-serif'
   },

--- a/frontend/src/styles/Variables.ts
+++ b/frontend/src/styles/Variables.ts
@@ -36,6 +36,7 @@ export const Variables = {
     font_medium_36: '500 36px "Pretendard-Variable", sans-serif',
     font_medium_24: '500 24px "Pretendard-Variable", sans-serif',
     font_medium_20: '500 20px "Pretendard-Variable", sans-serif',
+    font_medium_18: '500 20px "Pretendard-Variable", sans-serif',
     font_medium_16: '500 16px "Pretendard-Variable", sans-serif',
     font_bold_72: '700 72px "Pretendard-Variable", sans-serif',
     font_bold_56: '700 56px "Pretendard-Variable", sans-serif',

--- a/frontend/src/styles/Variables.ts
+++ b/frontend/src/styles/Variables.ts
@@ -43,7 +43,8 @@ export const Variables = {
     font_bold_36: '700 36px "Pretendard-Variable", sans-serif',
     font_bold_32: '700 32px "Pretendard-Variable", sans-serif',
     font_bold_24: '700 24px "Pretendard-Variable", sans-serif',
-    font_bold_20: '700 20px "Pretendard-Variable", sans-serif'
+    font_bold_20: '700 20px "Pretendard-Variable", sans-serif',
+    font_bold_16: '700 16px "Pretendard-Variable", sans-serif'
   },
   shadow: {
     shadow_floating: '0px 4px 8px #00000040'

--- a/frontend/src/utils/arrangement.ts
+++ b/frontend/src/utils/arrangement.ts
@@ -1,5 +1,5 @@
 // 참여자 수에 따른 위치를 계산하는 함수
-export const calculatePosition = (count: number, radius: number): [number, number][] => {
+export const calculatePosition = (count: number, shortRadius: number, longRadius: number): [number, number][] => {
   const positions: [number, number][] = [];
   const centerX = 0;
   const centerY = 0;
@@ -7,8 +7,8 @@ export const calculatePosition = (count: number, radius: number): [number, numbe
 
   for (let i = 0; i < count; i++) {
     const angle = angleDiff * i;
-    const x = centerX + radius * Math.sin(angle);
-    const y = centerY + radius * Math.cos(angle);
+    const x = centerX + longRadius * Math.sin(angle);
+    const y = centerY + shortRadius * Math.cos(angle);
     positions.push([x, y]);
   }
 


### PR DESCRIPTION
close #12 
close #47

# ✅ 주요 작업
- [x] 참여자 ui 원형 -> 타원형 배치로 수정
- [x] 참여자 리스트 profile item 추가
- [x] landing 페이지 폰트크기 및 헤더 높이 수정

> 작업 결과를 눈으로 확인할 수 있는 스크린샷 등이 있다면 첨부해주세요
![image](https://github.com/user-attachments/assets/115caf2e-d2ff-446b-a723-4cc809b5e91f)
# 📚 학습 키워드
타원 위의 점의 좌표

# 💭 고민과 해결과정
<img src="https://github.com/user-attachments/assets/280a450a-49e2-4399-a36a-9262f4d25e70" width='450' height='350'>

기존 원형 배치의 경우 가운데 질문 표시 영역에 제한이 있어, 원형 -> 타원 배치로 수정했습니다.
- 장축(longRadius), 단축(shortRadius) 구분
```ts
// 참여자 수에 따른 위치를 계산하는 함수
export const calculatePosition = (count: number, shortRadius: number, longRadius: number): [number, number][] => {
  const positions: [number, number][] = [];
  const centerX = 0;
  const centerY = 0;
  const angleDiff = (2 * Math.PI) / count;

  for (let i = 0; i < count; i++) {
    const angle = angleDiff * i;
    const x = centerX + longRadius * Math.sin(angle);
    const y = centerY + shortRadius * Math.cos(angle);
    positions.push([x, y]);
  }

  return positions;
};
```
# 📌 이슈 사항
사용자 프로필 이미지 미반영(임시 프로필 사진 지정)