### PR TITLE
절대경로가 인식되지 않는 문제 수정

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -2,7 +2,7 @@ import js from '@eslint/js';
 import importPlugin from 'eslint-plugin-import';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
-import globals from 'globals';
+import globals, { node } from 'globals';
 import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
@@ -76,6 +76,9 @@ export default tseslint.config(
         typescript: {
           alwaysTryTypes: true, //import하는 모듈의 @type/**에서 .d.ts파일을 찾아 타입 추론
           project: './tsconfig.json' // tsconfig.json 파일의 위치를 명시. 생략 시, 현재 위치에서 가장 가까운 tsconfig.json이 인식됨
+        },
+        node: {
+          paths: ['src'] //node_modules에서 모듈을 찾을 때 참고할 경로
         }
       }
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -36,7 +36,8 @@
         "typescript": "~5.6.2",
         "typescript-eslint": "^8.13.0",
         "vite": "^5.4.10",
-        "vite-plugin-svgr": "^4.3.0"
+        "vite-plugin-svgr": "^4.3.0",
+        "vite-tsconfig-paths": "^5.1.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3741,6 +3742,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -5465,6 +5472,26 @@
         "typescript": ">=4.2.0"
       }
     },
+    "node_modules/tsconfck": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.4.tgz",
+      "integrity": "sha512-kdqWFGVJqe+KGYvlSO9NIaWn9jT1Ny4oKVzAJsKii5eoE9snzTJzL4+MMVOMn+fikWGFmKEylcXL710V/kIPJQ==",
+      "dev": true,
+      "bin": {
+        "tsconfck": "bin/tsconfck.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -5741,6 +5768,25 @@
       },
       "peerDependencies": {
         "vite": ">=2.6.0"
+      }
+    },
+    "node_modules/vite-tsconfig-paths": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-5.1.2.tgz",
+      "integrity": "sha512-gEIbKfJzSEv0yR3XS2QEocKetONoWkbROj6hGx0FHM18qKUojhvcokQsxQx5nMkelZq2n37zbSGCJn+FSODSjA==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "globrex": "^0.1.2",
+        "tsconfck": "^3.0.3"
+      },
+      "peerDependencies": {
+        "vite": "*"
+      },
+      "peerDependenciesMeta": {
+        "vite": {
+          "optional": true
+        }
       }
     },
     "node_modules/which": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -39,6 +39,7 @@
     "typescript": "~5.6.2",
     "typescript-eslint": "^8.13.0",
     "vite": "^5.4.10",
-    "vite-plugin-svgr": "^4.3.0"
+    "vite-plugin-svgr": "^4.3.0",
+    "vite-tsconfig-paths": "^5.1.2"
   }
 }

--- a/frontend/src/pages/room/questionsView.tsx
+++ b/frontend/src/pages/room/questionsView.tsx
@@ -2,11 +2,11 @@ import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
 
 import ClockIcon from '@/assets/icons/clock.svg?react';
+import { QuestionInput } from '@/components';
 import { useQuestionsStore, useSocketStore } from '@/stores/';
 import { flexStyle, Variables } from '@/styles';
 import { Question } from '@/types';
 import { getRemainingSeconds } from '@/utils';
-import { QuestionInput } from '@/components';
 
 const questionTitleStyle = css({
   font: Variables.typography.font_bold_32,

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -31,5 +31,5 @@
       "@/*": ["src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "**/*.ts", "**/*.tsx"]
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,7 @@
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 import svgr from 'vite-plugin-svgr';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 // https://vite.dev/config/
 export default defineConfig({
@@ -11,7 +12,8 @@ export default defineConfig({
         plugins: ['@emotion/babel-plugin']
       }
     }),
-    svgr()
+    svgr(),
+    tsconfigPaths()
   ],
   resolve: {
     alias: [


### PR DESCRIPTION
close #ISSUE-NUMBER

# ✅ 주요 작업
- [x] 절대경로가 인식되지 않는 문제 수정

# 📚 학습 키워드

# 💭 고민과 해결과정
어제 절대경로를 사용하도록 alias 설정을 했는데 eslint에서 모듈 경로를 인식하지 못하는 오류가 있어 다음과 같이 `eslint.config.js` 파일에서 node에서 사용되는 절대 경로를 src로 설정해주었습니다.

```js
settings: {
      'import/resolver': {
        typescript: {
          alwaysTryTypes: true, //import하는 모듈의 @type/**에서 .d.ts파일을 찾아 타입 추론
          project: './tsconfig.json' // tsconfig.json 파일의 위치를 명시. 생략 시, 현재 위치에서 가장 가까운 tsconfig.json이 인식됨
        },
        node: {
          paths: ['src'] //node_modules에서 모듈을 찾을 때 참고할 경로
        }
      }
    }
```

# 📌 이슈 사항
