### PR TITLE
질문 표시 시 페이드인, 다음질문 시 전환 페이드아웃, 답변입력란 표시 애니메이션 추가

### DIFF
--- a/frontend/src/pages/room/KeywordsView.tsx
+++ b/frontend/src/pages/room/KeywordsView.tsx
@@ -7,7 +7,7 @@ import { Variables } from '@/styles';
 
 const KeywordsContainer = css`
   width: 100%;
-  margin-top: 10px;
+  margin-top: 50px;
   display: flex;
   justify-content: center;
   flex-wrap: wrap;

--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -38,7 +38,7 @@ const SubjectContainer = (shortRadius: number, longRadius: number) => css`
   position: absolute;
   bottom: ${shortRadius}px;
   left: ${longRadius}px;
-  transform: translate(-50%, 20%);
+  transform: translate(-50%, 50%);
   white-space: nowrap;
 `;
 

--- a/frontend/src/styles/animation.ts
+++ b/frontend/src/styles/animation.ts
@@ -54,3 +54,13 @@ export const hoverGrowJumpAnimation = ({ scale = 1.035, height = '0.7rem' } = {}
     },
     hoverGrow(scale)
   );
+
+export const fadeIn = keyframes({
+  from: { opacity: 0 },
+  to: { opacity: 1 }
+});
+
+export const fadeOut = keyframes({
+  from: { opacity: 1 },
+  to: { opacity: 0 }
+});

--- a/frontend/src/styles/index.ts
+++ b/frontend/src/styles/index.ts
@@ -1,3 +1,3 @@
-export { rotate, growAndShrink, hoverGrowJumpAnimation } from './animation';
+export { rotate, growAndShrink, hoverGrowJumpAnimation, fadeIn, fadeOut } from './animation';
 export { flexStyle } from './flex';
 export { Variables } from './Variables';


### PR DESCRIPTION
close #18 

# ✅ 주요 작업
- [x] 질문이 표시되고 사라질 때 페이드인, 페이드아웃 애니메이션 추가
- [x] 질문이 표시되고 잠시 뒤 답변 입력란과 제한시간이 질문을 위로 밀어내며 표시되도록 애니메이션을 추가했습니다.

https://github.com/user-attachments/assets/bfcd5c4f-4fa3-44a6-9bd0-8b4ecff55784

(테스트에 용이하게 첫 번째 질문은 5초뒤에 넘기게 해놨습니다)

# 📚 학습 키워드
`css transition` `css animation`

# 💭 고민과 해결과정
삽질 x 10000...

# 📌 이슈 사항
- 의도했던 애니메이션이 생각보다 복잡한 타이밍 제어와 상태관리를 요구해서인지.. 아니면 제가 애니메이션을 잘 못 다루는건지 로직이 복잡합니다 ㅜㅜ 일단 워드클라우드 UI 작업이 이번 주 주요 작업이므로, 주말에 더 자연스럽고 로직도 복잡하지 않게 개선해보겠습니다..