### PR TITLE
클라이언트의 키워드 입력(선택), 선택 취소 및 키워드 통계 게이트웨이 작성

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "@nestjs/cli": "^10.0.0",
         "@nestjs/schematics": "^10.0.0",
         "@nestjs/testing": "^10.0.0",
+        "@types/async-lock": "^1.4.2",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.2",
         "@types/node": "^20.3.1",
@@ -2153,6 +2154,13 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/async-lock": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@types/async-lock/-/async-lock-1.4.2.tgz",
+      "integrity": "sha512-HlZ6Dcr205BmNhwkdXqrg2vkFMN2PluI7Lgr8In3B3wE5PiQHhjRqtW/lGdVU9gw+sM0JcIDx2AN+cW8oSWIcw==",
       "dev": true,
       "license": "MIT"
     },

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/platform-express": "^10.0.0",
         "@nestjs/platform-socket.io": "^10.4.6",
         "@nestjs/websockets": "^10.4.6",
+        "async-lock": "^1.4.1",
         "reflect-metadata": "^0.2.0",
         "rxjs": "^7.8.1",
         "uuid": "^11.0.2"
@@ -3052,6 +3053,12 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-lock": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/async-lock/-/async-lock-1.4.1.tgz",
+      "integrity": "sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==",
       "license": "MIT"
     },
     "node_modules/asynckit": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/platform-socket.io": "^10.4.6",
     "@nestjs/websockets": "^10.4.6",
+    "async-lock": "^1.4.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1",
     "uuid": "^11.0.2"

--- a/backend/package.json
+++ b/backend/package.json
@@ -35,6 +35,7 @@
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",
+    "@types/async-lock": "^1.4.2",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.2",
     "@types/node": "^20.3.1",

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -4,11 +4,14 @@ import { AppService } from './app.service';
 import { RoomsGateway } from './rooms/gateway/rooms.gateway';
 import { RoomsService } from './rooms/service/rooms.service';
 import { RoomsController } from './rooms/controller/rooms.controller';
+import { EmpathyGateway } from './empathy/gateway/empathy.gateway';
+import { EmpathyService } from './empathy/service/empathy.service';
+import { EmpathyInMemoryRepository } from './empathy/repository/empathy.in-memory.repository';
 
 @Module({
   imports: [],
   controllers: [AppController, RoomsController],
-  providers: [AppService, RoomsGateway, RoomsService],
+  providers: [AppService, RoomsGateway, RoomsService, EmpathyGateway, EmpathyService, EmpathyInMemoryRepository],
 })
 export class AppModule {
 }

--- a/backend/src/empathy/dto/empathy.keyword.alert.dto.ts
+++ b/backend/src/empathy/dto/empathy.keyword.alert.dto.ts
@@ -1,0 +1,17 @@
+import { EmpathyKeywordInfoDto } from './empathy.keyword.info.dto';
+
+export class EmpathyKeywordAlertDto {
+  readonly questionId: number;
+  readonly keyword: string;
+  readonly count: number;
+
+  constructor(questionId: number, keyword: string, count: number) {
+    this.questionId = questionId;
+    this.keyword = keyword;
+    this.count = count;
+  }
+
+  static ofEmpathyKeywordInfo(empathyKeywordInfo: EmpathyKeywordInfoDto) {
+    return new this(empathyKeywordInfo.questionId, empathyKeywordInfo.keyword, empathyKeywordInfo.count);
+  }
+}

--- a/backend/src/empathy/dto/empathy.keyword.info.dto.ts
+++ b/backend/src/empathy/dto/empathy.keyword.info.dto.ts
@@ -1,0 +1,20 @@
+export const RESPONSE_STATUS = {
+  PICK: 'pick',
+  RELEASE: 'release',
+} as const;
+
+export type ResponseStatus = typeof RESPONSE_STATUS[keyof typeof RESPONSE_STATUS];
+
+export class EmpathyKeywordInfoDto {
+  readonly questionId: number;
+  readonly keyword: string;
+  readonly status: ResponseStatus;
+  readonly count: number;
+
+  constructor(questionId: number, keyword: string, status: ResponseStatus, count: number) {
+    this.questionId = questionId;
+    this.keyword = keyword;
+    this.status = status;
+    this.count = count;
+  }
+}

--- a/backend/src/empathy/dto/empathy.keyword.request.dto.ts
+++ b/backend/src/empathy/dto/empathy.keyword.request.dto.ts
@@ -1,0 +1,4 @@
+export class EmpathyKeywordRequestDto {
+  questionId: number;
+  keyword: string;
+}

--- a/backend/src/empathy/dto/empathy.keyword.response.dto.ts
+++ b/backend/src/empathy/dto/empathy.keyword.response.dto.ts
@@ -1,0 +1,13 @@
+import { EmpathyKeywordInfoDto, ResponseStatus } from './empathy.keyword.info.dto';
+
+export class EmpathyKeywordResponseDto {
+  readonly questionId: number;
+  readonly keyword: string;
+  readonly status: ResponseStatus;
+
+  constructor({ questionId, keyword, status }: EmpathyKeywordInfoDto) {
+    this.questionId = questionId;
+    this.keyword = keyword;
+    this.status = status;
+  }
+}

--- a/backend/src/empathy/gateway/empathy.gateway.spec.ts
+++ b/backend/src/empathy/gateway/empathy.gateway.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EmpathyGateway } from './empathy.gateway';
+import { EmpathyService } from '../service/empathy.service';
+import { EmpathyInMemoryRepository } from '../repository/empathy.in-memory.repository';
+
+describe('EmpathyGateway', () => {
+  let gateway: EmpathyGateway;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EmpathyGateway, EmpathyService, EmpathyInMemoryRepository],
+    }).compile();
+
+    gateway = module.get<EmpathyGateway>(EmpathyGateway);
+  });
+
+  it('should be defined', () => {
+    expect(gateway).toBeDefined();
+  });
+});

--- a/backend/src/empathy/gateway/empathy.gateway.ts
+++ b/backend/src/empathy/gateway/empathy.gateway.ts
@@ -40,7 +40,7 @@ export class EmpathyGateway {
   }: EmpathyKeywordRequestDto): Promise<EmpathyKeywordResponseDto> {
     const roomId = client.data.roomId;
     const clientId = client.id;
-    const empathyKeywordInfoDto = await this.empathyService.addKeyword(roomId, questionId, keyword, clientId);
+    const empathyKeywordInfoDto = await this.empathyService.removeKeyword(roomId, questionId, keyword, clientId);
 
     this.server.to(roomId).emit('empathy:keyword:count', EmpathyKeywordAlertDto.ofEmpathyKeywordInfo(empathyKeywordInfoDto));
 

--- a/backend/src/empathy/gateway/empathy.gateway.ts
+++ b/backend/src/empathy/gateway/empathy.gateway.ts
@@ -1,0 +1,57 @@
+import { ConnectedSocket, MessageBody, SubscribeMessage, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import { EmpathyKeywordRequestDto } from '../dto/empathy.keyword.request.dto';
+import { EmpathyKeywordResponseDto } from '../dto/empathy.keyword.response.dto';
+import { EmpathyService } from '../service/empathy.service';
+import { EmpathyKeywordAlertDto } from '../dto/empathy.keyword.alert.dto';
+
+@WebSocketGateway({
+  cors: {
+    origin: '*',
+    methods: ['GET', 'POST'],
+  },
+  namespace: 'empathy'
+})
+export class EmpathyGateway {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(private readonly empathyService: EmpathyService) {
+  }
+
+  @SubscribeMessage('keyword:pick')
+  async pickKeyword(@ConnectedSocket() client: Socket, @MessageBody() {
+    questionId,
+    keyword
+  }: EmpathyKeywordRequestDto): Promise<EmpathyKeywordResponseDto> {
+    const roomId = client.data.roomId;
+    const clientId = client.id;
+    const empathyKeywordInfoDto = await this.empathyService.addKeyword(roomId, questionId, keyword, clientId);
+
+    this.server.to(roomId).emit('empathy:keyword:count', EmpathyKeywordAlertDto.ofEmpathyKeywordInfo(empathyKeywordInfoDto));
+
+    return new EmpathyKeywordResponseDto(empathyKeywordInfoDto);
+  }
+
+  @SubscribeMessage('keyword:release')
+  async releaseKeyword(@ConnectedSocket() client: Socket, @MessageBody() {
+    questionId,
+    keyword
+  }: EmpathyKeywordRequestDto): Promise<EmpathyKeywordResponseDto> {
+    const roomId = client.data.roomId;
+    const clientId = client.id;
+    const empathyKeywordInfoDto = await this.empathyService.addKeyword(roomId, questionId, keyword, clientId);
+
+    this.server.to(roomId).emit('empathy:keyword:count', EmpathyKeywordAlertDto.ofEmpathyKeywordInfo(empathyKeywordInfoDto));
+
+    return new EmpathyKeywordResponseDto(empathyKeywordInfoDto);
+  }
+
+  @SubscribeMessage('keyword:result')
+  broadcastKeywordStatistics(@ConnectedSocket() client: Socket) {
+    const roomId = client.data.roomId;
+    const statistics = this.empathyService.getStatistics(roomId);
+
+    this.server.to(roomId).emit('empathy:keyword:result', statistics);
+  }
+}

--- a/backend/src/empathy/repository/empathy.in-memory.repository.spec.ts
+++ b/backend/src/empathy/repository/empathy.in-memory.repository.spec.ts
@@ -1,0 +1,153 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EmpathyInMemoryRepository } from './empathy.in-memory.repository';
+
+describe('EmpathyInMemoryRepository', () => {
+  let repository: EmpathyInMemoryRepository;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EmpathyInMemoryRepository],
+    }).compile();
+
+    repository = module.get<EmpathyInMemoryRepository>(EmpathyInMemoryRepository);
+  });
+
+  it('should be defined', () => {
+    expect(repository).toBeDefined();
+  });
+
+  test('같은 클라이언트일 경우 키워드는 중복 추가되지 않는다', async () => {
+    // given
+    const testRoomId = 'testRoomId';
+    const testQuestionId = 1;
+    const testKeyword = 'testKeyword';
+    const testClient = 'testClient';
+
+    // when
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword, testClient);
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword, testClient);
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword, testClient);
+
+    // then
+    const statistics = repository.calculateStatistics(testRoomId);
+    const clientStats = statistics.get(testClient);
+
+    expect(clientStats.length).toBe(1);
+    expect(clientStats[0].count).toBe(1);
+    expect(clientStats[0].keyword).toBe(testKeyword);
+  });
+
+  test('다른 클라이언트가 같은 키워드를 입력하면 키워드 카운트는 증가한다', async () => {
+    // given
+    const testRoomId = 'testRoomId';
+    const testQuestionId = 1;
+    const testKeyword = 'testKeyword';
+
+    const client1 = 'client1';
+    const client2 = 'client2';
+    const client3 = 'client3';
+
+    // when
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword, client1);
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword, client2);
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword, client3);
+
+    // then
+    const statistics = repository.calculateStatistics(testRoomId);
+
+    const client1Stats = statistics.get(client1);
+    const client2Stats = statistics.get(client2);
+    const client3Stats = statistics.get(client3);
+
+    const allClientStats = [client1Stats, client2Stats, client3Stats];
+
+    allClientStats.forEach(clientStats => {
+      expect(clientStats.length).toBe(1);
+      expect(clientStats[0].keyword).toBe(testKeyword);
+      expect(clientStats[0].count).toBe(allClientStats.length);
+    });
+  });
+
+  test('같은 주제에 대해 여러 키워드를 입력한다', async () => {
+    // given
+    const testRoomId = 'testRoomId';
+    const testQuestionId = 1;
+    const testKeyword1 = 'testKeyword1';
+    const testKeyword2 = 'testKeyword2';
+    const testKeyword3 = 'testKeyword3';
+    const testClient = 'testClient';
+
+    // when
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword1, testClient);
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword2, testClient);
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword3, testClient);
+
+    // then
+    const statistics = repository.calculateStatistics(testRoomId);
+    const clientStats = statistics.get(testClient);
+
+    expect(clientStats.length).toBe(3);
+    expect(clientStats.every(clientStat => clientStat.questionId === testQuestionId))
+      .toBe(true);
+    expect(clientStats.map(clientStat => clientStat.keyword)).toEqual(
+      expect.arrayContaining([testKeyword1, testKeyword2, testKeyword3]));
+  });
+
+  test('다른 주제에 대해 같은 키워드를 입력한다', async () => {
+    // given
+    const testRoomId = 'testRoomId';
+    const testQuestionId1 = 1;
+    const testQuestionId2 = 2;
+    const testQuestionId3 = 3;
+    const testKeyword = 'testKeyword';
+    const testClient = 'testClient';
+
+    // when
+    await repository.addKeyword(testRoomId, testQuestionId1, testKeyword, testClient);
+    await repository.addKeyword(testRoomId, testQuestionId2, testKeyword, testClient);
+    await repository.addKeyword(testRoomId, testQuestionId3, testKeyword, testClient);
+
+    // then
+    const statistics = repository.calculateStatistics(testRoomId);
+    const clientStats = statistics.get(testClient);
+
+    expect(clientStats.length).toBe(3);
+    expect(clientStats.every(clientStat => clientStat.keyword === testKeyword))
+      .toBe(true);
+    expect(clientStats.map(clientStat => clientStat.questionId)).toEqual(
+      expect.arrayContaining([testQuestionId1, testQuestionId2, testQuestionId3]));
+  });
+
+  test('키워드를 제거한다', async () => {
+    // given
+    const testRoomId = 'testRoomId';
+    const testQuestionId = 1;
+    const testKeyword = 'testKeyword';
+    const testClient = 'testClient';
+
+    // when
+    await repository.addKeyword(testRoomId, testQuestionId, testKeyword, testClient);
+    await repository.removeKeyword(testRoomId, testQuestionId, testKeyword, testClient);
+
+    // then
+    const statistics = repository.calculateStatistics(testRoomId);
+    expect(Array.from(statistics.keys()).length).toBe(0);
+  });
+
+  test('통계 산출과 동시에 기존 데이터는 삭제된다', async () => {
+    // given
+    const testRoomId = 'testRoomId';
+    const testClient = 'testClient';
+
+    // when
+    await repository.addKeyword(testRoomId, 1, 'testKeyword', testClient);
+
+    // then
+    const statistics = repository.calculateStatistics(testRoomId);
+    const clientStats = statistics.get(testClient);
+    expect(clientStats.length).toBe(1);
+
+    const repeatStatistics = repository.calculateStatistics(testRoomId);
+    expect(Array.from(repeatStatistics.keys()).length).toBe(0);
+  });
+});

--- a/backend/src/empathy/repository/empathy.in-memory.repository.ts
+++ b/backend/src/empathy/repository/empathy.in-memory.repository.ts
@@ -51,7 +51,7 @@ export class EmpathyInMemoryRepository {
       const participants = this.roomQuestionKeywordParticipants.get(roomId)?.get(questionId)?.get(keyword);
       participants?.delete(participantId);
 
-      return new EmpathyKeywordInfoDto(questionId, keyword, RESPONSE_STATUS.PICK, participants?.size ?? 0);
+      return new EmpathyKeywordInfoDto(questionId, keyword, RESPONSE_STATUS.RELEASE, participants?.size ?? 0);
     });
   }
 

--- a/backend/src/empathy/repository/empathy.in-memory.repository.ts
+++ b/backend/src/empathy/repository/empathy.in-memory.repository.ts
@@ -1,0 +1,114 @@
+import { Injectable } from '@nestjs/common';
+import { EmpathyKeywordInfoDto, RESPONSE_STATUS } from '../dto/empathy.keyword.info.dto';
+import * as AsyncLock from 'async-lock';
+import { EmpathyKeywordAlertDto } from '../dto/empathy.keyword.alert.dto';
+
+type SerializedEmpathyInfo = {
+  questionId: number,
+  keyword: string,
+  participants: Set<string>
+};
+
+@Injectable()
+export class EmpathyInMemoryRepository {
+  private readonly roomQuestionKeywordParticipants = new Map<string, Map<number, Map<string, Set<string>>>>();
+  private readonly lock = new AsyncLock();
+
+  private getOrCreateValue<K, V>(map: Map<K, V>, key: K, defaultValueCalculator: () => V): V {
+    let value = map.get(key);
+
+    if (value === undefined) {
+      value = defaultValueCalculator();
+      map.set(key, value);
+    }
+
+    return value;
+  }
+
+  async addKeyword(roomId: string, questionId: number, keyword: string, participantId: string): Promise<EmpathyKeywordInfoDto> {
+    return await this.lock.acquire(`${ roomId }`, async () => {
+      const questionKeywordParticipants = this.getOrCreateValue(
+        this.roomQuestionKeywordParticipants,
+        roomId,
+        () => new Map<number, Map<string, Set<string>>>()
+      );
+
+      const keywordParticipants = this.getOrCreateValue(
+        questionKeywordParticipants,
+        questionId,
+        () => new Map<string, Set<string>>()
+      );
+
+      const participants = this.getOrCreateValue(keywordParticipants, keyword, () => new Set<string>());
+      participants.add(participantId);
+
+      return new EmpathyKeywordInfoDto(questionId, keyword, RESPONSE_STATUS.PICK, participants.size);
+    });
+  }
+
+  async removeKeyword(roomId: string, questionId: number, keyword: string, participantId: string): Promise<EmpathyKeywordInfoDto> {
+    return await this.lock.acquire(`${ roomId }`, async () => {
+      const participants = this.roomQuestionKeywordParticipants.get(roomId)?.get(questionId)?.get(keyword);
+      participants?.delete(participantId);
+
+      return new EmpathyKeywordInfoDto(questionId, keyword, RESPONSE_STATUS.PICK, participants?.size ?? 0);
+    });
+  }
+
+  calculateStatistics(roomId: string): Map<string, EmpathyKeywordAlertDto[]> {
+    const questionKeywordParticipants = this.roomQuestionKeywordParticipants.get(roomId);
+
+    if (questionKeywordParticipants === undefined) {
+      return new Map();
+    }
+
+    const sortedSerializedEmpathyInfos = this.serializeEmpathyInfos(questionKeywordParticipants)
+      .sort(this.compareByParticipantsSize);
+
+    this.roomQuestionKeywordParticipants.delete(roomId);
+
+    return this.createStatistics(sortedSerializedEmpathyInfos);
+  }
+
+  private serializeEmpathyInfos(questionKeywordParticipants: Map<number, Map<string, Set<string>>>) {
+    return Array.from(questionKeywordParticipants.entries())
+      .reduce((result, [questionId, keywordParticipants]) => {
+        const serializeEmpathyInfos = Array.from(keywordParticipants.entries())
+          .map(([keyword, participants]) => {
+            return { questionId, keyword, participants } as SerializedEmpathyInfo;
+          });
+
+        result.push(...serializeEmpathyInfos);
+
+        return result;
+      }, [] as SerializedEmpathyInfo[]);
+  }
+
+  private compareByParticipantsSize(a: SerializedEmpathyInfo, b: SerializedEmpathyInfo): number {
+    return b.participants.size - a.participants.size;
+  }
+
+  private createStatistics(sortedEmpathyInfos: SerializedEmpathyInfo[]) {
+    const statistics = new Map<string, EmpathyKeywordAlertDto[]>();
+
+    for (const empathyInfo of sortedEmpathyInfos) {
+      const alertDto = new EmpathyKeywordAlertDto(
+        empathyInfo.questionId,
+        empathyInfo.keyword,
+        empathyInfo.participants.size
+      );
+
+      for (const participantId of empathyInfo.participants) {
+        const participantStats = this.getOrCreateValue(
+          statistics,
+          participantId,
+          () => new Array<EmpathyKeywordAlertDto>()
+        );
+
+        participantStats.push(alertDto);
+      }
+    }
+
+    return statistics;
+  }
+}

--- a/backend/src/empathy/service/empathy.service.spec.ts
+++ b/backend/src/empathy/service/empathy.service.spec.ts
@@ -1,0 +1,19 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { EmpathyService } from './empathy.service';
+import { EmpathyInMemoryRepository } from '../repository/empathy.in-memory.repository';
+
+describe('EmpathyService', () => {
+  let service: EmpathyService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [EmpathyService, EmpathyInMemoryRepository],
+    }).compile();
+
+    service = module.get<EmpathyService>(EmpathyService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/empathy/service/empathy.service.ts
+++ b/backend/src/empathy/service/empathy.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { EmpathyInMemoryRepository } from '../repository/empathy.in-memory.repository';
+import { EmpathyKeywordInfoDto } from '../dto/empathy.keyword.info.dto';
+
+@Injectable()
+export class EmpathyService {
+
+  constructor(private readonly empathyInMemoryRepository: EmpathyInMemoryRepository) {
+  }
+
+  async addKeyword(roomId: string, questionId: number, keyword: string, clientId: string): Promise<EmpathyKeywordInfoDto> {
+    return await this.empathyInMemoryRepository.addKeyword(roomId, questionId, keyword, clientId);
+  }
+
+  async removeKeyword(roomId: string, questionId: number, keyword: string, clientId: string): Promise<EmpathyKeywordInfoDto> {
+    return await this.empathyInMemoryRepository.removeKeyword(roomId, questionId, keyword, clientId);
+  }
+
+  getStatistics(roomId: string) {
+    return this.empathyInMemoryRepository.calculateStatistics(roomId);
+  }
+}

--- a/backend/src/rooms/controller/rooms.controller.spec.ts
+++ b/backend/src/rooms/controller/rooms.controller.spec.ts
@@ -1,5 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RoomsController } from './rooms.controller';
+import { RoomsService } from '../service/rooms.service';
 
 describe('RoomsController', () => {
   let controller: RoomsController;
@@ -7,6 +8,7 @@ describe('RoomsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [RoomsController],
+      providers: [RoomsService]
     }).compile();
 
     controller = module.get<RoomsController>(RoomsController);

--- a/backend/src/rooms/entity/Topic.ts
+++ b/backend/src/rooms/entity/Topic.ts
@@ -1,10 +1,10 @@
 export class Topic {
-  private readonly id: number;
+  private readonly questionId: number;
   private readonly title: string;
   private readonly expirationTime: string;
 
-  constructor(id: number, title: string, addSecond: number) {
-    this.id = id;
+  constructor(questionId: number, title: string, addSecond: number) {
+    this.questionId = questionId;
     this.title = title;
     const date = new Date();
     date.setSeconds(date.getSeconds() + addSecond);

--- a/backend/src/rooms/gateway/rooms.gateway.spec.ts
+++ b/backend/src/rooms/gateway/rooms.gateway.spec.ts
@@ -1,12 +1,13 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RoomsGateway } from './rooms.gateway';
+import { RoomsService } from '../service/rooms.service';
 
 describe('RoomsGateway', () => {
   let gateway: RoomsGateway;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [RoomsGateway],
+      providers: [RoomsGateway, RoomsService],
     }).compile();
 
     gateway = module.get<RoomsGateway>(RoomsGateway);


### PR DESCRIPTION
close #63
close #64
close #65

# ✅ 주요 작업
- 참가자의 키워드 입력(선택) 이벤트 처리
- 참가자의 키워드 선택 취소 이벤트 처리
- 해당 방의 통계 이벤트 처리
- 통계 테스트코드 작성

# 📚 학습 키워드
- nest
- jest

# 💭 고민과 해결과정
## 효율적인 통계 방법은?
통계를 위해서는 각 사용자마다 특정 주제(질문)에 어떤 키워드를 입력했는지를 알려줘야 합니다. 또한 해당 통계는 같은 키워드를 입력한 사람이 많을 수록 상위에 띄워주어야 합니다.

`참가자 id: [ { 주제 id, 키워드, 선택한 참가자 수 }, ...]`를 모든 참가자에 대해 도출하는 방법은 여러 방법이 있을 것입니다.

처음에는 통계 데이터를 먼저 산출한 후, 각 참가자마다 선택 수를 정렬하도록 작업했습니다. 다만 해당 정렬은 참가자마다 수행될 필요가 없었습니다. 모든 키워드에 대해 한번만 정렬 후, 각 참가자 통계에 넣어주면 문제가 없을 것이라 판단되었습니다.

## 정렬을 꼭 BE에서 해야 하는가?
클라이언트에서 정렬을 수행한다면 서버의 연산시간을 줄일 수 있을 것입니다. 하지만 클라이언트의 환경이 좋지 않을 시 순간적으로 버벅이는 현상이 생길 수 있지 않을까 하는 생각이 들어 서버에서 정렬하도록 구성하였습니다.

## 주제와 키워드를 하나의 문자열로 구성하면 좋지 않을까?
`3: 바나나`, `1: 고양이`처럼 주제와 키워드를 하나의 문자열로 표기한다면 훨씬 간단하면서도 처리하기 쉬운 상태를 지닐 수 있을 것입니다.

하지만 이는 FE분들과 상의해보아야 할 사항이므로, 이번 PR에서는 따로 관리하도록 구성했습니다.

# 📌 이슈 사항
## 통계 자동 발행 이벤트 미구축
특정 방의 모든 키워드 입력이 종료되는 시간에 맞춰 통계 이벤트가 발생해야 합니다. 하지만 이는 아래와 같은 이유로 아직 구축되지 못했습니다.

- FE에서의 빠른 개발을 위한 강제 이벤트 처리
- 현재 모든 키워드 입력 종료를 담당하는 이벤트 처리기가 존재하지 않음
- 클라이언트가 입력 시간을 연장하는 상황을 어떻게 대처할 지 논의하지 않음

이는 다음 PR부터 적용해 볼 예정입니다.

## 논의해야 할 사항
- 정렬의 효율성
- 주제와 키워드 묶어 관리