### PR TITLE
분석결과 전 로딩페이지 추가, 나머지 소켓 이벤트 연결

### DIFF
--- a/frontend/src/assets/icons/closeX.svg
+++ b/frontend/src/assets/icons/closeX.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="20px" height="20px" viewBox="-0.5 0 25 25" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 21.32L21 3.32001" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M3 3.32001L21 21.32" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/assets/icons/edit.svg
+++ b/frontend/src/assets/icons/edit.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="40px" height="40px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M18 10L21 7L17 3L14 6M18 10L8 20H4V16L14 6M18 10L14 6" stroke="#ffffff" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/frontend/src/components/ProfileEditButton.tsx
+++ b/frontend/src/components/ProfileEditButton.tsx
@@ -1,0 +1,158 @@
+import { css } from '@emotion/react';
+import { useEffect, useState } from 'react';
+
+import Modal from './common/Modal';
+import { useParticipantsStore, useSocketStore } from '@/stores';
+
+import Profile from '@/assets/icons/profile.svg?react';
+import Edit from '@/assets/icons/edit.svg?react';
+import { flexStyle, Variables } from '@/styles';
+
+const profileImageStyle = css`
+  width: 50px;
+  height: 50px;
+  border-radius: 50%;
+  cursor: pointer;
+`;
+
+const inputStyle = css`
+  font: ${Variables.typography.font_medium_16};
+  text-align: start;
+  border-radius: 8px;
+  border: 1px solid ${Variables.colors.surface_alt};
+  padding: 5px;
+  width: 150px;
+`;
+
+const editButtonStyle = css`
+  position: absolute;
+  width: 27px;
+  height: 27px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  right: 5px;
+  bottom: 5px;
+  border: none;
+  border-radius: 50%;
+  background-color: ${Variables.colors.surface_black};
+  cursor: pointer;
+`;
+
+const saveButtonStyle = css`
+  border: none;
+  border-radius: 8px;
+  padding: 4px 5px;
+  color: white;
+  background-color: ${Variables.colors.surface_strong};
+`;
+
+const nicknameContainerStyle = css`
+  display: flex;
+  gap: 5px;
+  align-items: center;
+`;
+
+const profileEditContainerStyle = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  min-width: 250px;
+  height: 200px;
+`;
+
+const ProfileEditButton = () => {
+  const { socket, connect, disconnect } = useSocketStore();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [nicknameInput, setNicknameInput] = useState('');
+  const { participants, setParticipants } = useParticipantsStore();
+
+  const handleProfileUpdate = (newProfile: { participantId: string; nickname: string }) => {
+    setParticipants((prev) => ({
+      ...prev,
+      [newProfile.participantId]: {
+        ...prev[newProfile.participantId],
+        nickname: newProfile.nickname
+      }
+    }));
+  };
+
+  const handleSaveNickname = () => {
+    const participantId = socket?.id || '';
+    if (participantId && nicknameInput) {
+      handleProfileUpdate({ participantId, nickname: nicknameInput });
+    }
+    setIsEditing(false);
+    setIsModalOpen(false);
+  };
+
+  useEffect(() => {
+    if (!socket) connect();
+
+    if (socket) {
+      const currentUserId = socket?.id || '';
+      const currentNickname = participants[currentUserId]?.nickname || '알 수 없음';
+
+      // 사용자 정보 요청 및 프로필 업데이트 이벤트 설정
+      socket.emit('join', { nickname: currentNickname });
+      socket.on('participant:info:update', handleProfileUpdate);
+
+      return () => {
+        socket.off('participant:info:update', handleProfileUpdate);
+        disconnect();
+      };
+    }
+  }, [socket, setParticipants]);
+
+  return (
+    <div>
+      <button css={profileImageStyle} onClick={() => setIsModalOpen(true)}>
+        <Profile width={'100%'} height={'100%'} />
+      </button>
+      <Modal
+        closeButton={true}
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsEditing(false);
+          setIsModalOpen(false);
+        }}
+      >
+        <div css={profileEditContainerStyle}>
+          <h3>내 프로필</h3>
+          <div css={{ position: 'relative', width: '100px', height: '100px' }}>
+            <Profile width={'100%'} height={'100%'} />
+            {!isEditing && (
+              <button css={editButtonStyle} onClick={() => setIsEditing(true)}>
+                <Edit width={'22px'} height={'22px'} />
+              </button>
+            )}
+          </div>
+          <div css={flexStyle(10)}>
+            <span>닉네임</span>
+            {isEditing ? (
+              <div css={nicknameContainerStyle}>
+                <input
+                  css={inputStyle}
+                  value={nicknameInput}
+                  onChange={(e) => setNicknameInput(e.target.value)}
+                  placeholder="새 닉네임"
+                />
+                <button css={saveButtonStyle} onClick={handleSaveNickname}>
+                  저장
+                </button>
+              </div>
+            ) : (
+              <div css={nicknameContainerStyle}>
+                <div css={inputStyle}>{participants[socket?.id || '']?.nickname || '알 수 없음'}</div>
+              </div>
+            )}
+          </div>
+        </div>
+      </Modal>
+    </div>
+  );
+};
+
+export default ProfileEditButton;

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 
 import { Variables } from '@/styles';
+import CloseX from '@/assets/icons/closeX.svg?react';
 
 const ModalOverlayStyle = css`
   position: relative;
@@ -17,7 +18,7 @@ const ModalContentStyle = css`
   left: ${Variables.spacing.spacing_md};
   background-color: ${Variables.colors.surface_white};
   max-width: 300px;
-  height: 600px;
+  max-height: 600px;
   padding: ${Variables.spacing.spacing_sm};
   text-align: center;
   border-radius: 8px;
@@ -25,8 +26,24 @@ const ModalContentStyle = css`
   z-index: 101; /* overlay보다 위에 위치 */
 `;
 
+const closeButtonStyle = css`
+  position: absolute;
+  top: 10px;
+  right: 10px;
+`;
+
 // 모달 컴포넌트
-const Modal = ({ isOpen, onClose, children }: { isOpen: boolean; onClose: () => void; children: React.ReactNode }) => {
+const Modal = ({
+  closeButton = false,
+  isOpen,
+  onClose,
+  children
+}: {
+  closeButton?: boolean;
+  isOpen: boolean;
+  onClose: () => void;
+  children: React.ReactNode;
+}) => {
   if (!isOpen) return null;
 
   return (
@@ -34,9 +51,11 @@ const Modal = ({ isOpen, onClose, children }: { isOpen: boolean; onClose: () => 
       <div css={ModalOverlayStyle} onClick={onClose}></div>
       <div css={ModalContentStyle}>
         {children}
-        <button css={css``} onClick={onClose}>
-          닫기
-        </button>
+        {closeButton && (
+          <button css={closeButtonStyle} onClick={onClose}>
+            <CloseX width={'15px'} height={'15px'} />
+          </button>
+        )}
       </div>
     </>
   );

--- a/frontend/src/hooks/useParticipants.ts
+++ b/frontend/src/hooks/useParticipants.ts
@@ -34,6 +34,14 @@ const useParticipants = (roomId: string | null, setLoading: React.Dispatch<React
     }));
   };
 
+  const handleParticipantExit = (Participant: { participantId: string; nickname: string }) => {
+    setParticipants((prev) => {
+      const newParticipants = { ...prev };
+      delete newParticipants[Participant.participantId];
+      return newParticipants;
+    });
+  };
+
   useEffect(() => {
     if (!socket) {
       connect();
@@ -45,8 +53,11 @@ const useParticipants = (roomId: string | null, setLoading: React.Dispatch<React
       // 새로운 참여자 알림 이벤트
       socket.on('participant:join', handleParticipantJoin);
 
+      // 참여자 퇴장 이벤트
+      socket.on('participant:exit', handleParticipantExit);
       return () => {
         socket?.off('participant:join', handleParticipantJoin);
+        socket?.off('participant:exit', handleParticipantExit);
         disconnect();
       };
     }

--- a/frontend/src/hooks/useParticipants.ts
+++ b/frontend/src/hooks/useParticipants.ts
@@ -4,12 +4,11 @@ import { convertArrayToObject } from '@/utils';
 import { ParticipantItem } from '@/types';
 import { useParticipantsStore } from '@/stores';
 
-const useParticipants = (roomId: string | null) => {
+const useParticipants = (roomId: string | null, setLoading: React.Dispatch<React.SetStateAction<boolean>>) => {
   const { socket, connect, disconnect } = useSocketStore();
   const { hostId, participants, setParticipants, setHostId } = useParticipantsStore();
   const [roomExists, setRoomExists] = useState(true);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
-  const [loading, setLoading] = useState<boolean>(true);
 
   // 참가자 목록 응답 처리
   const handleJoinResponse = (response: {
@@ -53,7 +52,7 @@ const useParticipants = (roomId: string | null) => {
     }
   }, [socket, roomId, setParticipants]);
 
-  return { participants, hostId, currentUserId, roomExists, loading };
+  return { participants, hostId, currentUserId, roomExists };
 };
 
 export default useParticipants;

--- a/frontend/src/hooks/useParticipants.ts
+++ b/frontend/src/hooks/useParticipants.ts
@@ -6,7 +6,7 @@ import { useParticipantsStore } from '@/stores';
 
 const useParticipants = (roomId: string | null, setLoading: React.Dispatch<React.SetStateAction<boolean>>) => {
   const { socket, connect, disconnect } = useSocketStore();
-  const { hostId, participants, setParticipants, setHostId } = useParticipantsStore();
+  const { hostId, setHostId, participants, setParticipants } = useParticipantsStore();
   const [roomExists, setRoomExists] = useState(true);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
 
@@ -42,6 +42,10 @@ const useParticipants = (roomId: string | null, setLoading: React.Dispatch<React
     });
   };
 
+  const handleHostChange = (Host: { participantId: string; nickname: string }) => {
+    setHostId(Host.participantId);
+  };
+
   useEffect(() => {
     if (!socket) {
       connect();
@@ -55,9 +59,13 @@ const useParticipants = (roomId: string | null, setLoading: React.Dispatch<React
 
       // 참여자 퇴장 이벤트
       socket.on('participant:exit', handleParticipantExit);
+
+      //호스트 변경 알림 이벤트
+      socket.on('participant:host:change', handleHostChange);
       return () => {
-        socket?.off('participant:join', handleParticipantJoin);
-        socket?.off('participant:exit', handleParticipantExit);
+        socket.off('participant:join', handleParticipantJoin);
+        socket.off('participant:exit', handleParticipantExit);
+        socket.off('participant:host:change', handleHostChange);
         disconnect();
       };
     }

--- a/frontend/src/pages/LoadingPage.tsx
+++ b/frontend/src/pages/LoadingPage.tsx
@@ -5,25 +5,37 @@ import { LoadingSpinnerWave } from '@/components/common';
 import { Variables } from '@/styles';
 
 const loadingPageStyle = css({
-  width: '100vw',
-  height: '100vh',
+  width: '100%',
+  height: '100%',
 
   display: 'flex',
   gap: '2rem',
   flexDirection: 'column',
   justifyContent: 'center',
-  alignItems: 'center'
+  alignItems: 'center',
+  textAlign: 'center'
 });
 
-const LoadingPage = () => {
+interface LoadingPageProps {
+  isAnalyzing?: boolean; //분석 페이지 여부
+  loadingMessage?: string;
+}
+const LoadingPage = ({ isAnalyzing = false, loadingMessage }: LoadingPageProps) => {
   return (
     <div css={loadingPageStyle}>
+      {isAnalyzing && (
+        <p css={{ font: Variables.typography.font_medium_18, color: Variables.colors.text_default }}>
+          공감 포인트 모으기가 끝났어요.
+          <br />
+          조금만 기다리시면 통계를 확인하거나 컨텐츠를 공유할 수 있어요.
+        </p>
+      )}
       <div css={{ position: 'relative' }}>
         <LoadingSpinnerWave />
       </div>
-      <p css={{ font: Variables.typography.font_medium_16, color: Variables.colors.text_alt }}>
-        관심사를 나누러 가는 중...
-      </p>
+      {loadingMessage && (
+        <p css={{ font: Variables.typography.font_medium_16, color: Variables.colors.text_alt }}>{loadingMessage}</p>
+      )}
     </div>
   );
 };

--- a/frontend/src/pages/room/KeywordsView.tsx
+++ b/frontend/src/pages/room/KeywordsView.tsx
@@ -40,8 +40,10 @@ const KeywordsView = ({ questionId }: KeywordsViewProps) => {
 
   return (
     <div css={KeywordsContainer}>
-      {keywords[questionId].map((keywordObject) => (
-        <div key={`${questionId}-${keywordObject.keyword}`} css={KeywordStyle}>{keywordObject.keyword}</div>
+      {keywords[questionId]?.map((keywordObject) => (
+        <div key={`${questionId}-${keywordObject.keyword}`} css={KeywordStyle}>
+          {keywordObject.keyword}
+        </div>
       ))}
     </div>
   );

--- a/frontend/src/pages/room/questionsView.tsx
+++ b/frontend/src/pages/room/questionsView.tsx
@@ -8,6 +8,7 @@ import { Question } from '@/types';
 import { getRemainingSeconds } from '@/utils';
 import KeywordsView from './KeywordsView';
 import { MAX_LONG_RADIUS } from '@/constants';
+import LoadingPage from '../LoadingPage';
 
 const MainContainer = css([{ width: '100%' }, flexStyle(5, 'column')]);
 
@@ -83,6 +84,7 @@ interface QuestionViewProps {
 const QuestionsView = ({ onQuestionStart }: QuestionViewProps) => {
   const { socket } = useSocketStore();
   const { questions, setQuestions } = useQuestionsStore();
+  const [loading, setLoading] = useState<boolean>(false);
 
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
   const [timeLeft, setTimeLeft] = useState(0);
@@ -114,6 +116,17 @@ const QuestionsView = ({ onQuestionStart }: QuestionViewProps) => {
           setIsFadeIn(false);
           setIsQuestionMovedUp(false);
           setShowInput(false);
+
+          //마지막 질문이 끝난 경우의 처리
+          if (currentQuestionIndex === questions.length - 1) {
+            //전환 페이지 표시
+            setLoading(true);
+
+            //서버에게 종료 알림 전송
+            if (socket) {
+              socket.emit('empathy:end');
+            }
+          }
           return prevTime;
         }
         return prevTime - 1;
@@ -151,7 +164,9 @@ const QuestionsView = ({ onQuestionStart }: QuestionViewProps) => {
     }
   }, [isFadeIn]);
 
-  return questions.length > 0 && currentQuestionIndex < questions.length ? (
+  return loading ? (
+    <LoadingPage isAnalyzing={true} />
+  ) : questions.length > 0 && currentQuestionIndex < questions.length ? (
     <div css={MainContainer}>
       <div key={currentQuestionIndex} css={viewContainerStyle(isFadeIn)}>
         <div css={{ position: 'relative', width: '100%' }}>

--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -44,7 +44,9 @@ const SubjectContainer = (shortRadius: number, longRadius: number) => css`
 
 const Room = () => {
   const roomId = useParams<{ roomId: string }>().roomId || null;
-  const { participants, hostId, currentUserId, roomExists, loading } = useParticipants(roomId);
+  const [loading, setLoading] = useState<boolean>(true);
+
+  const { participants, hostId, currentUserId, roomExists } = useParticipants(roomId, setLoading);
   const { radius, increaseRadius, increaseLongRadius } = useRadiusStore();
 
   const [isIntroViewActive, setIsIntroViewActive] = useState(true);
@@ -81,7 +83,7 @@ const Room = () => {
     <>
       {/* <Header /> */}
       {loading ? (
-        <LoadingPage />
+        <LoadingPage loadingMessage="관심사를 나누러 가는 중..." />
       ) : (
         <>
           <div css={backgroundStyle}>


### PR DESCRIPTION
close #ISSUE-NUMBER

# ✅ 주요 작업
- [x] 분석결과 전, 로딩페이지 추가
- [x] 참여자 퇴장 알림 이벤트 연결
- [x] 호스트 변경 알림 이벤트 연결
- [x] 프로필 편집 버튼(모달) 추가 및 프로필 업데이트 소켓 이벤트 연결
  - 버튼으로 만들어두기만하고 따로 페이지에 넣진않았습니다
> 작업 결과를 눈으로 확인할 수 있는 스크린샷 등이 있다면 첨부해주세요
<img width='500' height='450' src="https://github.com/user-attachments/assets/e777d755-f7ae-4837-9f3c-af839da96197">

![Animation](https://github.com/user-attachments/assets/6191d80a-5a6f-47c0-8ff3-f2e8ab31c7f0)

# 📚 학습 키워드
css
typescript
# 💭 고민과 해결과정
- 마지막 질문이 나오고 로딩페이지로 전환될 때, 참여자 ui를 그대로 두고 로딩을 가운데 배치했습니다.
- `분석결과 전 로딩 페이지`인지 여부를 props로 받도록 loadingPage 컴포넌트를 수정했습니다. 또한 loadingMessage를 props로 받아 로딩 스피너 밑에 표시되는 메시지를 다르게 전달할 수 있도록 했습니다.
# 📌 이슈 사항
- 키워드 표시 로직은 구현이 된 상태이고, 백엔드 코드가 완성되면 테스트해볼 예정
[[FE] 서버로부터 데이터를 받는 데에 실패했을 경우 재요청을 보내고 Toast 메시지를 띄운다](https://github.com/boostcampwm-2024/web11-road_to_friendly/issues/32)
[[FE] 서버가 전달한 질문 리스트 중 마지막 질문의 타임스탬프에 기록된 시간이 되면 전환 페이지를 띄우고 서버에게 종료 알림을 전송한다](https://github.com/boostcampwm-2024/web11-road_to_friendly/issues/29)
[[FE] 참여자별 상위 N개 키워드를 화면에 표시한다](https://github.com/boostcampwm-2024/web11-road_to_friendly/issues/31)
- 프로필은 임시 이미지로 지정