### PR TITLE
키워드 송신, 수신기능 서버와 연결 및 store에 키워드 반영 로직 수정

### DIFF
--- a/frontend/src/components/QuestionInput.tsx
+++ b/frontend/src/components/QuestionInput.tsx
@@ -1,10 +1,28 @@
 import { useToast } from '@/hooks';
 import { useSocketStore } from '@/stores';
+import { Variables } from '@/styles';
+import { KeywordResponse } from '@/types';
+import { css } from '@emotion/react';
 import { useState } from 'react';
 
 interface QuestionInputProps {
   currentQuestionIndex: number;
 }
+
+const inputStyle = css`
+  width: 100%;
+  height: 30px;
+  margin-top: 12px;
+  font: ${Variables.typography.font_medium_18};
+  color: ${Variables.colors.text_alt};
+  text-align: center;
+  line-height: 30px;
+  border: none;
+  border-bottom: 1px solid black;
+  outline: none;
+  background-color: transparent;
+  opacity: 1;
+`;
 
 const QuestionInput = ({ currentQuestionIndex }: QuestionInputProps) => {
   const [keyword, setKeyword] = useState('');
@@ -20,14 +38,31 @@ const QuestionInput = ({ currentQuestionIndex }: QuestionInputProps) => {
     }
 
     if (socket && socket.connected) {
-      socket?.emit('empathy:keyword:pick', { questionId: currentQuestionIndex, keyword });
+      socket.emit('keyword:pick', { questionId: currentQuestionIndex + 1, keyword }, (response: KeywordResponse) => {
+        console.log(response);
+        if (response.status !== 'pick') {
+          /*
+            TODO: 추후 서버 로직에서 status가 ok로 바뀐다면 수정 필요
+            */
+          openToast({ text: '서버에서 문제가 생긴 것 같아요. Enter를 눌러 다시 전송해주세요.', type: 'error' });
+        } else {
+          setKeyword('');
+        }
+      });
     } else {
       openToast({ text: '연결 상태가 원활하지 않은 것 같아요. Enter를 눌러 다시 전송해주세요.', type: 'error' });
     }
   }
 
   return (
-    <input type="text" value={keyword} onChange={(e) => setKeyword(e.target.value)} onKeyDown={(e) => handleEnter(e)} />
+    <input
+      type="text"
+      value={keyword}
+      placeholder="답변을 입력해주세요"
+      css={inputStyle}
+      onChange={(e) => setKeyword(e.target.value)}
+      onKeyDown={(e) => handleEnter(e)}
+    />
   );
 };
 

--- a/frontend/src/pages/room/KeywordsView.tsx
+++ b/frontend/src/pages/room/KeywordsView.tsx
@@ -28,12 +28,12 @@ interface KeywordsViewProps {
 
 const KeywordsView = ({ questionId }: KeywordsViewProps) => {
   const { socket } = useSocketStore();
-  const { keywords, appendKeyword } = useKeywordsStore();
+  const { keywords, upsertKeyword } = useKeywordsStore();
 
   useEffect(() => {
     if (socket) {
       socket.on('empathy:keyword:count', (response: { questionId: number; keyword: string; count: number }) => {
-        appendKeyword(response);
+        upsertKeyword(response);
       });
     }
   }, [socket]);

--- a/frontend/src/pages/room/questionsView.tsx
+++ b/frontend/src/pages/room/questionsView.tsx
@@ -8,6 +8,7 @@ import { Question } from '@/types';
 import { getRemainingSeconds } from '@/utils';
 import KeywordsView from './KeywordsView';
 import { MAX_LONG_RADIUS } from '@/constants';
+import { QuestionInput } from '@/components';
 import LoadingPage from '../LoadingPage';
 
 const MainContainer = css([{ width: '100%' }, flexStyle(5, 'column')]);
@@ -62,21 +63,6 @@ const progressBarStyle = css`
   }
 `;
 
-const inputStyle = css`
-  width: 100%;
-  height: 30px;
-  margin-top: 12px;
-  font: ${Variables.typography.font_medium_18};
-  color: ${Variables.colors.text_alt};
-  text-align: center;
-  line-height: 30px;
-  border: none;
-  border-bottom: 1px solid black;
-  outline: none;
-  background-color: transparent;
-  opacity: 1;
-`;
-
 interface QuestionViewProps {
   onQuestionStart: () => void;
 }
@@ -100,8 +86,8 @@ const QuestionsView = ({ onQuestionStart }: QuestionViewProps) => {
         onQuestionStart();
         if (response.questions.length > 0) {
           const firstQuestionTimeLeft = getRemainingSeconds(new Date(response.questions[0].expirationTime), new Date());
-          setTimeLeft(5);
-          setInitialTimeLeft(5);
+          setTimeLeft(300);
+          setInitialTimeLeft(300);
         }
       });
     }
@@ -175,7 +161,7 @@ const QuestionsView = ({ onQuestionStart }: QuestionViewProps) => {
           >{`Q${currentQuestionIndex + 1}. ${questions[currentQuestionIndex].title}`}</h1>
           {showInput && (
             <div css={{ width: '100%', animation: `${fadeIn} 2s ease forwards` }}>
-              <input placeholder="답변을 입력해주세요" css={inputStyle} />
+              <QuestionInput currentQuestionIndex={currentQuestionIndex} />
               <div css={progressWrapperStyle}>
                 <ClockIcon width="35px" height="35px" fill="#000" />
                 <progress
@@ -189,7 +175,7 @@ const QuestionsView = ({ onQuestionStart }: QuestionViewProps) => {
           )}
           <div></div>
         </div>
-        <KeywordsView questionId={questions[currentQuestionIndex].id} />
+        <KeywordsView questionId={questions[currentQuestionIndex].questionId} />
       </div>
     </div>
   ) : null;

--- a/frontend/src/stores/keywords.ts
+++ b/frontend/src/stores/keywords.ts
@@ -1,50 +1,169 @@
 import { create } from 'zustand';
 
-import { Keyword } from '@/types';
+import { Keyword, KeywordInfo } from '@/types';
+
+interface KeywordMapElement {
+  [keyword: string]: { count: number; index: number };
+}
+
+interface KeywordsMap {
+  [questionId: number]: KeywordMapElement;
+}
+
+interface Keywords {
+  [questionId: number]: Keyword[];
+}
+
+interface Count {
+  [count: number]: number;
+}
+
+interface Counts {
+  [questionId: number]: number[];
+}
+
+interface CountMap {
+  [questionId: number]: Count;
+}
 
 interface KeywordsStore {
-  keywords: {
-    [questionId: number]: Keyword[];
-  };
-  appendKeyword: (newKeywordData: { questionId: number; keyword: string; count: number }) => void;
+  keywords: Keywords;
+  keywordsMap: KeywordsMap;
+  counts: Counts;
+  countMap: CountMap;
+  upsertKeyword: (targetKeyword: KeywordInfo) => void;
   deleteKeyword: (targetKeyword: { questionId: number; keyword: string }) => void;
+}
+
+function appendArrayUnique<T>(array: T[], element: T): T[] {
+  if (!array.includes(element)) return [...array, element];
+  return array;
+}
+
+function syncCountMap(array: number[], countMap: Count, element: number): Count {
+  if (!array.includes(element)) {
+    return { ...countMap, [element]: 1 };
+  }
+  return countMap;
+}
+
+function appendKeyword(
+  keywordsMap: KeywordsMap,
+  keywords: Keywords,
+  counts: Counts,
+  countMap: CountMap,
+  newKeywordData: { questionId: number; keyword: string; count: number }
+) {
+  const { questionId, keyword } = newKeywordData;
+  const prevLength = keywords[questionId]?.length ?? 0;
+  return {
+    keywords: {
+      ...keywords,
+      [questionId]: [...(keywords[questionId] || []), { keyword, count: 1 }]
+    },
+    counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], 1) },
+    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, 1) },
+    keywordsMap: {
+      ...keywordsMap,
+      [questionId]: {
+        ...(keywordsMap[questionId] || {}),
+        [keyword]: { count: 1, index: prevLength }
+      }
+    }
+  };
+}
+
+function modifyKeywordCount(
+  keywordsMap: KeywordsMap,
+  keywords: Keywords,
+  counts: Counts,
+  countMap: CountMap,
+  targetKeyword: { questionId: number; keyword: string; count: number }
+) {
+  const { questionId, keyword, count } = targetKeyword;
+  const modifiedKeywordsMapElement = {
+    ...(keywordsMap[questionId] || {}),
+    [keyword]: { count, index: 0 }
+  };
+
+  const modifiedKeywordsElement = [...keywords[questionId]].sort(
+    (a, b) => modifiedKeywordsMapElement[b.keyword].count - modifiedKeywordsMapElement[a.keyword].count
+  );
+
+  modifiedKeywordsElement.forEach((keyword, index) => {
+    const key = keyword.keyword;
+    modifiedKeywordsMapElement[key].index = index;
+  });
+
+  return {
+    keywords: {
+      ...keywords,
+      [questionId]: modifiedKeywordsElement
+    },
+    counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], count).sort((a, b) => b - a) },
+    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, count) },
+    keywordsMap: {
+      ...keywordsMap,
+      [questionId]: modifiedKeywordsMapElement
+    }
+  };
 }
 
 export const useKeywordsStore = create<KeywordsStore>((set) => ({
   keywords: {
     1: [
-      { keyword: '삼계탕', count: 1 },
-      { keyword: '미역국', count: 1 },
+      { keyword: '김치찌개', count: 1 },
+      { keyword: '떡볶이', count: 1 },
       { keyword: '제육볶음', count: 1 },
-      { keyword: '떡볶이', count: 2 },
-      { keyword: '김치찌개', count: 1 }
+      { keyword: '미역국', count: 1 },
+      { keyword: '삼계탕', count: 1 }
     ],
     2: [
-      { keyword: '갈비탕', count: 1 },
-      { keyword: '찜닭', count: 1 },
-      { keyword: '장충동왕족발보쌈', count: 1 },
-      { keyword: '닭칼국수다 어쩔래어쩔어쩔', count: 1 },
-      { keyword: '불고기', count: 1 },
+      { keyword: '만두전골', count: 1 },
       { keyword: '비빔밥', count: 1 },
-      { keyword: '만두전골', count: 1 }
+      { keyword: '불고기', count: 1 },
+      { keyword: '닭칼국수다 어쩔래어쩔어쩔', count: 1 },
+      { keyword: '장충동왕족발보쌈', count: 1 },
+      { keyword: '찜닭', count: 1 },
+      { keyword: '갈비탕', count: 1 }
     ],
     3: [],
     4: [],
     5: []
   },
-  appendKeyword: (newKeywordData) =>
+  counts: { 1: [1] },
+  countMap: { 1: { 1: 5 } },
+  keywordsMap: {
+    1: {
+      김치찌개: { count: 5, index: 0 },
+      떡볶이: { count: 4, index: 1 },
+      제육볶음: { count: 3, index: 2 },
+      미역국: { count: 2, index: 3 },
+      삼계탕: { count: 1, index: 4 }
+    },
+    2: {
+      만두전골: { count: 7, index: 0 },
+      비빔밥: { count: 6, index: 1 },
+      불고기: { count: 5, index: 2 },
+      '닭칼국수다 어쩔래어쩔어쩔': { count: 4, index: 3 },
+      장충동왕족발보쌈: { count: 3, index: 4 },
+      찜닭: { count: 2, index: 5 },
+      갈비탕: { count: 1, index: 6 }
+    },
+    3: {},
+    4: {},
+    5: {}
+  },
+
+  upsertKeyword: (targetKeyword) => {
     set((state) => {
-      const { questionId } = newKeywordData;
-      return {
-        keywords: {
-          ...state.keywords,
-          [questionId]: [
-            ...(state.keywords[questionId] || []),
-            { keyword: newKeywordData.keyword, count: newKeywordData.count }
-          ]
-        }
-      };
-    }),
+      const { questionId, keyword } = targetKeyword;
+      if (state.keywordsMap[questionId] && state.keywordsMap[questionId][keyword])
+        return modifyKeywordCount(state.keywordsMap, state.keywords, state.counts, state.countMap, targetKeyword);
+      return appendKeyword(state.keywordsMap, state.keywords, state.counts, state.countMap, targetKeyword);
+    });
+  },
+
   deleteKeyword: (targetKeyword) =>
     set((state) => {
       const updatedKeywords = state.keywords[targetKeyword.questionId]?.filter(

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -3,3 +3,4 @@ export type { Question } from './question';
 export type { Keyword } from './keyword';
 export type { Participant } from './participant';
 export type { ParticipantItem } from './ParticipantItem';
+export type { KeywordResponse } from './response';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 export type { ToastType, Position, ToastProps, ToastOption } from './toast';
 export type { Question } from './question';
-export type { Keyword } from './keyword';
+export type { Group, Keyword, KeywordInfo } from './keyword';
 export type { Participant } from './participant';
 export type { ParticipantItem } from './ParticipantItem';
 export type { KeywordResponse } from './response';

--- a/frontend/src/types/keyword.ts
+++ b/frontend/src/types/keyword.ts
@@ -1,4 +1,12 @@
+export type Group = 'Big' | 'Medium' | 'Small' | 'Tiny';
+
 export interface Keyword {
+  keyword: string;
+  count: number;
+}
+
+export interface KeywordInfo {
+  questionId: number;
   keyword: string;
   count: number;
 }

--- a/frontend/src/types/question.ts
+++ b/frontend/src/types/question.ts
@@ -1,5 +1,5 @@
 export interface Question {
-  id: number;
+  questionId: number;
   title: string;
   expirationTime: string;
 }

--- a/frontend/src/types/response.ts
+++ b/frontend/src/types/response.ts
@@ -1,0 +1,12 @@
+const RESPONSE_STATUS = {
+  PICK: 'pick',
+  RELEASE: 'release'
+} as const;
+
+type ResponseStatus = (typeof RESPONSE_STATUS)[keyof typeof RESPONSE_STATUS];
+
+export interface KeywordResponse {
+  readonly questionId: number;
+  readonly keyword: string;
+  readonly status: ResponseStatus;
+}


### PR DESCRIPTION
# ✅ 주요 작업
- [x] 백엔드와 타입 동기화
- [x] 답변 input 로직과 스타일 연결
- [x] 키워드 수신 시 존재하는 키워드인지 검사 및 정렬하도록 수정 

![키워드 추가 연동결과](https://github.com/user-attachments/assets/df77abd0-8ab1-45fc-bae9-fd4eba03a6b0)
- 키워드 추가 테스트를 용이하게 하기 위해 첫번째 질문의 시간을 300초로 늘렸습니다.

# 📚 학습 키워드
`zustand`, `socket.io`

# 💭 고민과 해결과정
### 백엔드와 타입 동기화
- 백엔드 타입을 가져와 프론트엔드에도 적용하였습니다. 일단은 필요한 부분만 가져왔는데, 추후 더 많은 타입을 동기화하면 좋을 것 같습니다.

### 키워드 수신 시 store 추가 로직 수정
- 서버에서 키워드 카운트 변경 이벤트를 보내줄 때, 하나의 키워드 정보만 보내주므로 기존 store에 해당 keyword가 존재하는지 검사하는 로직이 필요했습니다. string 검사를 매번 하는 건 비효율적이라고 생각해 map을 추가해 키워드명으로 배열 내의 해당하는 키워드를 바로 찾을 수 있게 하였으나, 효율적인 방법일지는 고민이 더 필요할 것 같습니다.
- 정렬은 현재 sort 함수로 구현되어 있어 `O(NlogN)`의 시간복잡도를 가집니다. 키워드가 1000개라고 가정했을 때 1ms 정도의 시간이 걸리므로 1000개정도까진 큰 무리가 없을 것으로 보입니다. 실제로 DOM 조작과 애니메이션을 적용했을 때 성능에 문제가 있는지, 방 인원수를 엄청나게 많이 두고 실험했을 때 무리가 생기지는 않는지 확인해본 뒤 수정의 필요성이 생긴다면 수정할 예정입니다.
- count의 경우 **`키워드의 카운트`가 아니라 `count의 count`** 입니다,, 같은 count를 가지는 키워드들이 총 몇개인지 기록해야 그룹화에서 동순위를 계산하기 용이하기 때문에 저장하였는데 이름이 헷갈리기 쉬운 것 같고 이 역시 최선의 방법일지 모르겠어서 좀 더 고민해볼 필요가 있을 것 같습니다.


# 📌 이슈 사항
현재 그룹화 알고리즘은 작업 중입니다. 그룹에 따른 스타일을 `map`으로 저장하였는데, 키워드 표시 방법이 정해지면 스타일 적용 방법도 달라질 수 있을 것 같아 PR에는 올리지 않았습니다.

현재 store를 마구 수정했더니 코드의 품질이 좋은 것 같지 않아 좀 더 깔끔하게 표현할 방법과 그룹화 알고리즘에 대한 고민, 그리고 `D3.js`에 대한 조사도 진행해보려고 합니다.