### PR TITLE
헤더에 프로필 버튼 추가 및 모달 컴포넌트 수정

### DIFF
--- a/frontend/src/components/ParticipantListSidebar.tsx
+++ b/frontend/src/components/ParticipantListSidebar.tsx
@@ -49,7 +49,7 @@ const ParticipantListSidebar = () => {
         onMouseEnter={() => setIsModalOpen(true)}
         onMouseLeave={() => setIsModalOpen(false)}
       />
-      <Modal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
+      <Modal position={'topLeft'} isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
         <div css={ListContainerStyle}>
           <div>참여자 리스트</div>
           {Object.keys(participants).map((participantId) => (

--- a/frontend/src/components/ProfileEditButton.tsx
+++ b/frontend/src/components/ProfileEditButton.tsx
@@ -9,8 +9,8 @@ import Edit from '@/assets/icons/edit.svg?react';
 import { flexStyle, Variables } from '@/styles';
 
 const profileImageStyle = css`
-  width: 50px;
-  height: 50px;
+  width: 40px;
+  height: 40px;
   border-radius: 50%;
   cursor: pointer;
 `;
@@ -107,7 +107,7 @@ const ProfileEditButton = () => {
   }, [socket, setParticipants]);
 
   return (
-    <div>
+    <>
       <button css={profileImageStyle} onClick={() => setIsModalOpen(true)}>
         <Profile width={'100%'} height={'100%'} />
       </button>
@@ -152,7 +152,7 @@ const ProfileEditButton = () => {
           </div>
         </div>
       </Modal>
-    </div>
+    </>
   );
 };
 

--- a/frontend/src/components/ProfileEditButton.tsx
+++ b/frontend/src/components/ProfileEditButton.tsx
@@ -112,6 +112,7 @@ const ProfileEditButton = () => {
         <Profile width={'100%'} height={'100%'} />
       </button>
       <Modal
+        position="topRight"
         closeButton={true}
         isOpen={isModalOpen}
         onClose={() => {

--- a/frontend/src/components/ProfileEditButton.tsx
+++ b/frontend/src/components/ProfileEditButton.tsx
@@ -107,7 +107,7 @@ const ProfileEditButton = () => {
   }, [socket, setParticipants]);
 
   return (
-    <>
+    <div>
       <button css={profileImageStyle} onClick={() => setIsModalOpen(true)}>
         <Profile width={'100%'} height={'100%'} />
       </button>
@@ -152,7 +152,7 @@ const ProfileEditButton = () => {
           </div>
         </div>
       </Modal>
-    </>
+    </div>
   );
 };
 

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -11,7 +11,8 @@ const headerWrapperStyle = css({
   right: 0,
   display: 'flex',
   width: '100%',
-  padding: 24
+  padding: '10px 24px',
+  minHeight: '80px'
 });
 
 const headerStyle = (paddingY: number) =>
@@ -37,7 +38,7 @@ interface HeaderProps {
   paddingY?: number;
 }
 
-const Header = ({ paddingY = 17 }: HeaderProps) => {
+const Header = ({ paddingY = 12 }: HeaderProps) => {
   const location = useLocation();
   return (
     <header css={headerWrapperStyle}>

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 
 import { Variables } from '@/styles';
 import ProfileEditButton from '@components/ProfileEditButton';
+import { useLocation } from 'react-router-dom';
 
 const headerWrapperStyle = css({
   position: 'fixed',
@@ -37,6 +38,7 @@ interface HeaderProps {
 }
 
 const Header = ({ paddingY = 17 }: HeaderProps) => {
+  const location = useLocation();
   return (
     <header css={headerWrapperStyle}>
       <div css={headerStyle(paddingY)}>
@@ -46,7 +48,7 @@ const Header = ({ paddingY = 17 }: HeaderProps) => {
         <nav css={navStyle}>
           <button>튜토리얼</button>
           <button>라이트/다크</button>
-          <ProfileEditButton />
+          {location.pathname !== '/' && <ProfileEditButton />}
         </nav>
       </div>
     </header>

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/react';
 
 import { Variables } from '@/styles';
+import ProfileEditButton from '@components/ProfileEditButton';
 
 const headerWrapperStyle = css({
   position: 'fixed',
@@ -45,6 +46,7 @@ const Header = ({ paddingY = 17 }: HeaderProps) => {
         <nav css={navStyle}>
           <button>튜토리얼</button>
           <button>라이트/다크</button>
+          <ProfileEditButton />
         </nav>
       </div>
     </header>

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -12,10 +12,13 @@ const ModalOverlayStyle = css`
   z-index: 100;
 `;
 
-const ModalContentStyle = css`
+const ModalContentStyle = (top?: string, left?: string, right?: string, bottom?: string, isCenter?: boolean) => css`
   position: absolute;
-  top: ${Variables.spacing.spacing_lg};
-  left: ${Variables.spacing.spacing_md};
+  top: ${top ? top : 'unset'};
+  left: ${left ? left : 'unset'};
+  right: ${right ? right : 'unset'};
+  bottom: ${bottom ? bottom : 'unset'};
+  ${isCenter && 'transform: translate(-50%, -50%);'}
   background-color: ${Variables.colors.surface_white};
   max-width: 300px;
   max-height: 600px;
@@ -23,7 +26,7 @@ const ModalContentStyle = css`
   text-align: center;
   border-radius: 8px;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
-  z-index: 101; /* overlay보다 위에 위치 */
+  z-index: 999; /* overlay보다 위에 위치 */
 `;
 
 const closeButtonStyle = css`
@@ -37,19 +40,45 @@ const Modal = ({
   closeButton = false,
   isOpen,
   onClose,
-  children
+  children,
+  position = 'center'
 }: {
   closeButton?: boolean;
   isOpen: boolean;
   onClose: () => void;
   children: React.ReactNode;
+  position: 'topLeft' | 'topRight' | 'bottomRight' | 'center';
 }) => {
   if (!isOpen) return null;
+
+  // 위치에 따라 top, left, right, bottom 값을 결정
+  const getPosition = () => {
+    switch (position) {
+      case 'topLeft':
+        return { top: '24px', left: '24px', right: 'unset', bottom: 'unset', isCenter: false };
+      case 'topRight':
+        return { top: '120px', left: 'unset', right: '24px', bottom: 'unset', isCenter: false };
+      case 'bottomRight':
+        return { top: 'unset', left: 'unset', right: '24px', bottom: '24px', isCenter: false };
+      default:
+        return { top: '50%', left: '50%', right: 'unset', bottom: 'unset', isCenter: true };
+    }
+  };
+
+  const positionStyle = getPosition();
 
   return (
     <>
       <div css={ModalOverlayStyle} onClick={onClose}></div>
-      <div css={ModalContentStyle}>
+      <div
+        css={ModalContentStyle(
+          positionStyle.top,
+          positionStyle.left,
+          positionStyle.right,
+          positionStyle.bottom,
+          positionStyle.isCenter
+        )}
+      >
         {children}
         {closeButton && (
           <button css={closeButtonStyle} onClick={onClose}>

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -55,9 +55,9 @@ const Modal = ({
   const getPosition = () => {
     switch (position) {
       case 'topLeft':
-        return { top: '80px', left: '24px', right: 'unset', bottom: 'unset', isCenter: false };
+        return { top: '85px', left: '24px', right: 'unset', bottom: 'unset', isCenter: false };
       case 'topRight':
-        return { top: '80px', left: 'unset', right: '24px', bottom: 'unset', isCenter: false };
+        return { top: '85px', left: 'unset', right: '24px', bottom: 'unset', isCenter: false };
       case 'bottomRight':
         return { top: 'unset', left: 'unset', right: '24px', bottom: '24px', isCenter: false };
       default:

--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -55,9 +55,9 @@ const Modal = ({
   const getPosition = () => {
     switch (position) {
       case 'topLeft':
-        return { top: '24px', left: '24px', right: 'unset', bottom: 'unset', isCenter: false };
+        return { top: '80px', left: '24px', right: 'unset', bottom: 'unset', isCenter: false };
       case 'topRight':
-        return { top: '120px', left: 'unset', right: '24px', bottom: 'unset', isCenter: false };
+        return { top: '80px', left: 'unset', right: '24px', bottom: 'unset', isCenter: false };
       case 'bottomRight':
         return { top: 'unset', left: 'unset', right: '24px', bottom: '24px', isCenter: false };
       default:

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -1,4 +1,4 @@
 export const MIN_SHORT_RADIUS = 210; //반지름
 export const MIN_LONG_RADIUS = Math.floor((MIN_SHORT_RADIUS * 4) / 3); //장축:단축 = 4:3
-export const MAX_SHORT_RADIUS = 240;
+export const MAX_SHORT_RADIUS = 220;
 export const MAX_LONG_RADIUS = Math.floor((MAX_SHORT_RADIUS * 4) / 3);

--- a/frontend/src/pages/room/resultView.tsx
+++ b/frontend/src/pages/room/resultView.tsx
@@ -42,8 +42,8 @@ const ResultView = ({ participant, setIsResultView }: ResultViewProps) => {
   // const { openToast } = useToast();
 
   // useEffect(() => {
-  //   if (socket) {
-  //     socket.on('empathy:keyword:result', (response: CommonResult) => {
+  //   if (socket) {y:keyword:resul
+  //     socket.on('empatht', (response: CommonResult) => {
   //       setIsResultView(response.status === 'ok');
   //       if (response.status === 'ok') {
   //         Object.entries(response.body).forEach(([userId, array]) => {

--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -15,6 +15,7 @@ import LoadingPage from '../LoadingPage';
 import ResultInstruction from './resultInstruction';
 import RoomIntroView from './roomIntroView';
 import useParticipants from '@/hooks/useParticipants';
+import { Header } from '@components/common';
 
 const backgroundStyle = css`
   background: ${Variables.colors.surface_default};
@@ -24,6 +25,7 @@ const backgroundStyle = css`
   justify-content: center;
   align-items: center;
   flex-direction: column;
+  padding-top: 100px; /* 헤더 높이를 고려한 여백 추가 */
 `;
 
 const ParticipantsContainer = (shortRadius: number, longRadius: number) => css`
@@ -81,7 +83,7 @@ const Room = () => {
 
   return (
     <>
-      {/* <Header /> */}
+      <Header />
       {loading ? (
         <LoadingPage loadingMessage="관심사를 나누러 가는 중..." />
       ) : (


### PR DESCRIPTION
close #ISSUE-NUMBER

# ✅ 주요 작업
- [x] 헤더에 프로필 버튼 추가(프로필 편집 기능)
  - / 루트 경로가 아닐때만 프로필 표시가 되도록 수정
  - 모달 컴포넌트에 position props 추가(default는 center, 우상단/우하단/좌상단/센터)
```ts
const getPosition = () => {
    switch (position) {
      case 'topLeft':
        return { top: '85px', left: '24px', right: 'unset', bottom: 'unset', isCenter: false };
      case 'topRight':
        return { top: '85px', left: 'unset', right: '24px', bottom: 'unset', isCenter: false };
      case 'bottomRight':
        return { top: 'unset', left: 'unset', right: '24px', bottom: '24px', isCenter: false };
      default:
        return { top: '50%', left: '50%', right: 'unset', bottom: 'unset', isCenter: true };
    }
  };
```
> 작업 결과를 눈으로 확인할 수 있는 스크린샷 등이 있다면 첨부해주세요
![image](https://github.com/user-attachments/assets/846ff8d6-6fe3-4096-b9c9-c30a103a83f7)
![image](https://github.com/user-attachments/assets/d032d60d-630c-499f-8721-5de4847a89ea)

# 📚 학습 키워드

# 💭 고민과 해결과정

# 📌 이슈 사항
