### PR TITLE
각 도메인 별 모듈 분리

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,38 +1,13 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
-import { RoomsGateway } from './rooms/gateway/rooms.gateway';
-import { RoomsService } from './rooms/service/rooms.service';
-import { RoomsController } from './rooms/controller/rooms.controller';
-import { KeywordsGateway } from './keywords/gateway/keywords.gateway';
-import { KeywordsService } from './keywords/service/keywords.service';
-import { KeywordsInMemoryRepository } from './keywords/repository/keywords.in-memory.repository';
-import { ClientsGateway } from './clients/gateway/clients.gateway';
-import { ClientsService } from './clients/service/clients.service';
-import { RoomsInMemoryRepository } from './rooms/repository/rooms.in-memory.repository';
-import { HostGuard } from './rooms/guard/rooms.host.guard';
-import { JoinGuard } from './rooms/guard/rooms.join.guard';
-import { ExistGuard } from './rooms/guard/rooms.exist.guard';
-import { ConnectionGuard } from './rooms/guard/rooms.connection.guard';
+import { ClientsModule } from './clients/module/clients.module';
+import { RoomsModule } from './rooms/module/rooms.module';
+import { KeywordsModule } from './keywords/module/keywords.module';
 
 @Module({
-  imports: [],
-  controllers: [AppController, RoomsController],
-  providers: [
-    AppService,
-    RoomsGateway,
-    RoomsService,
-    RoomsInMemoryRepository,
-    HostGuard,
-    JoinGuard,
-    ExistGuard,
-    ConnectionGuard,
-    KeywordsGateway,
-    KeywordsService,
-    KeywordsInMemoryRepository,
-    ClientsGateway,
-    ClientsService,
-  ],
+  imports: [ClientsModule, RoomsModule, KeywordsModule],
+  controllers: [AppController],
+  providers: [AppService],
 })
-export class AppModule {
-}
+export class AppModule {}

--- a/backend/src/clients/module/clients.module.ts
+++ b/backend/src/clients/module/clients.module.ts
@@ -3,8 +3,6 @@ import { ClientsGateway } from '../gateway/clients.gateway';
 import { ClientsService } from '../service/clients.service';
 
 @Module({
-  imports: [],
-  controllers: [],
   providers: [ClientsGateway, ClientsService],
   exports: [ClientsService],
 })

--- a/backend/src/clients/module/clients.module.ts
+++ b/backend/src/clients/module/clients.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ClientsGateway } from '../gateway/clients.gateway';
+import { ClientsService } from '../service/clients.service';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [ClientsGateway, ClientsService],
+  exports: [ClientsService],
+})
+export class ClientsModule {}

--- a/backend/src/keywords/module/keywords.module.ts
+++ b/backend/src/keywords/module/keywords.module.ts
@@ -4,8 +4,6 @@ import { KeywordsService } from '../service/keywords.service';
 import { KeywordsInMemoryRepository } from '../repository/keywords.in-memory.repository';
 
 @Module({
-  imports: [],
-  controllers: [],
   providers: [KeywordsGateway, KeywordsService, KeywordsInMemoryRepository],
 })
 export class KeywordsModule {}

--- a/backend/src/keywords/module/keywords.module.ts
+++ b/backend/src/keywords/module/keywords.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { KeywordsGateway } from '../gateway/keywords.gateway';
+import { KeywordsService } from '../service/keywords.service';
+import { KeywordsInMemoryRepository } from '../repository/keywords.in-memory.repository';
+
+@Module({
+  imports: [],
+  controllers: [],
+  providers: [KeywordsGateway, KeywordsService, KeywordsInMemoryRepository],
+})
+export class KeywordsModule {}

--- a/backend/src/rooms/module/rooms.module.ts
+++ b/backend/src/rooms/module/rooms.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { RoomsController } from '../controller/rooms.controller';
+import { RoomsGateway } from '../gateway/rooms.gateway';
+import { RoomsService } from '../service/rooms.service';
+import { RoomsInMemoryRepository } from '../repository/rooms.in-memory.repository';
+import { HostGuard } from '../guard/rooms.host.guard';
+import { JoinGuard } from '../guard/rooms.join.guard';
+import { ExistGuard } from '../guard/rooms.exist.guard';
+import { ConnectionGuard } from '../guard/rooms.connection.guard';
+import { ClientsModule } from 'src/clients/module/clients.module';
+
+@Module({
+  imports: [ClientsModule],
+  controllers: [RoomsController],
+  providers: [RoomsGateway, RoomsService, RoomsInMemoryRepository, HostGuard, JoinGuard, ExistGuard, ConnectionGuard],
+})
+export class RoomsModule {}

--- a/backend/src/rooms/repository/rooms.in-memory.repository.spec.ts
+++ b/backend/src/rooms/repository/rooms.in-memory.repository.spec.ts
@@ -76,11 +76,26 @@ describe('RoomsGateway', () => {
   });
 
   describe('deleteRoom', () => {
-    it('should delete a room if it exists', async () => {
+    it('방이 존재하지 않으면 삭제되어야한다.', async () => {
       const roomId = repository.create();
 
       repository.deleteRoom(roomId);
       expect(repository.isExistRoom(roomId)).toBe(false);
+    });
+  });
+
+  describe('updateHost', () => {
+    it('호스트가 나가면 다른 참여자가 호스트가 되어야한다.', async () => {
+      const roomId = repository.create();
+      const firstClientId = 'client1';
+      const secondClientId = 'client2';
+
+      const hostId = repository.setHostIfHostUndefined(roomId, firstClientId);
+      expect(hostId).toBe(firstClientId);
+
+      repository.updateHost(roomId, secondClientId);
+
+      expect(repository.getHostId(roomId)).toBe(secondClientId);
     });
   });
 });


### PR DESCRIPTION
close #ISSUE-NUMBER

# ✅ 주요 작업
- 각 도메인 별 모듈 분리
- roomsInMemoryRepository updateHost 테스트 추가

# 📚 학습 키워드
 
# 💭 고민과 해결과정
- rooms, clients, keywords가 한번에 app.module에 들어가 있었는데 모듈로 분리하여 나눴습니다.
```
@Module({
  imports: [ClientsModule, RoomsModule, KeywordsModule],
  controllers: [AppController],
  providers: [AppService],
})
export class AppModule {}
```
# 📌 이슈 사항
