### PR TITLE
키워드 그룹화, 그룹에 따른 스타일/ 애니메이션 임시 적용

### DIFF
--- a/frontend/src/components/QuestionInput.tsx
+++ b/frontend/src/components/QuestionInput.tsx
@@ -39,7 +39,6 @@ const QuestionInput = ({ currentQuestionIndex }: QuestionInputProps) => {
 
     if (socket && socket.connected) {
       socket.emit('keyword:pick', { questionId: currentQuestionIndex + 1, keyword }, (response: KeywordResponse) => {
-        console.log(response);
         if (response.status !== 'pick') {
           /*
             TODO: 추후 서버 로직에서 status가 ok로 바뀐다면 수정 필요

--- a/frontend/src/components/RoomCreateButton.tsx
+++ b/frontend/src/components/RoomCreateButton.tsx
@@ -31,7 +31,6 @@ const RoomCreateButton = () => {
   const createRoom = async () => {
     try {
       setLoading(true);
-      console.log(config.SOCKET_SERVER_URL);
       const response = await fetch(`${config.SOCKET_SERVER_URL}/rooms`, {
         method: 'POST',
         headers: {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -2,3 +2,7 @@ export const MIN_SHORT_RADIUS = 210; //반지름
 export const MIN_LONG_RADIUS = Math.floor((MIN_SHORT_RADIUS * 4) / 3); //장축:단축 = 4:3
 export const MAX_SHORT_RADIUS = 240;
 export const MAX_LONG_RADIUS = Math.floor((MAX_SHORT_RADIUS * 4) / 3);
+
+export const BIG_THRESHOLD = 20;
+export const MIDEIUM_THRESHOLD = 40;
+export const SMALL_THRESHOLD = 60;

--- a/frontend/src/pages/room/KeywordsView.tsx
+++ b/frontend/src/pages/room/KeywordsView.tsx
@@ -3,45 +3,79 @@ import { useEffect } from 'react';
 
 import { useSocketStore } from '@/stores';
 import { useKeywordsStore } from '@/stores/keywords';
-import { Variables } from '@/styles';
+import { keywordStyleMap, Variables } from '@/styles';
+import { Group, Keyword, PrefixSum } from '@/types';
+import { BIG_THRESHOLD, MIDEIUM_THRESHOLD, SMALL_THRESHOLD } from '@/constants';
 
 const KeywordsContainer = css`
   width: 100%;
   margin-top: 50px;
   display: flex;
   justify-content: center;
+  align-items: center;
   flex-wrap: wrap;
   gap: 8px;
 `;
+
 const KeywordStyle = css`
   border: 1px solid black;
-  padding: 3px 10px;
+  height: fit-content;
+  padding: 0.5rem 0.75rem;
   background: ${Variables.colors.surface_word_default};
-  border-radius: 50px;
   text-align: center;
   min-width: 60px;
+  transition: font-size 0.3s ease;
 `;
 
 interface KeywordsViewProps {
   questionId: number;
 }
 
+function getKeywordGroup(keyword: Keyword, keywordCountSum: number, prefixSum: PrefixSum): Group {
+  const { count } = keyword;
+  const curPrefixSum = prefixSum[count];
+  const ratio = Math.ceil((curPrefixSum / keywordCountSum) * 100);
+
+  if (ratio < BIG_THRESHOLD) {
+    return 'Big';
+  } else if (ratio < MIDEIUM_THRESHOLD) {
+    return 'Medium';
+  } else if (ratio < SMALL_THRESHOLD) {
+    return 'Small';
+  }
+  return 'Tiny';
+}
+
 const KeywordsView = ({ questionId }: KeywordsViewProps) => {
   const { socket } = useSocketStore();
-  const { keywords, upsertKeyword } = useKeywordsStore();
+  const { keywords, prefixSumMap, upsertKeyword } = useKeywordsStore();
 
   useEffect(() => {
     if (socket) {
+      socket.off('empathy:keyword:count');
+
       socket.on('empathy:keyword:count', (response: { questionId: number; keyword: string; count: number }) => {
         upsertKeyword(response);
       });
     }
+
+    return () => {
+      socket?.off('empathy:keyword:count');
+    };
   }, [socket]);
 
   return (
     <div css={KeywordsContainer}>
       {keywords[questionId]?.map((keywordObject) => (
-        <div key={`${questionId}-${keywordObject.keyword}`} css={KeywordStyle}>
+        <div
+          key={`${questionId}-${keywordObject.keyword}`}
+          css={[
+            KeywordStyle,
+            keywordStyleMap(false)[
+              getKeywordGroup(keywordObject, keywords[questionId].length, prefixSumMap[questionId])
+            ]
+          ]}
+        >
           {keywordObject.keyword}
         </div>
       ))}

--- a/frontend/src/stores/keywords.ts
+++ b/frontend/src/stores/keywords.ts
@@ -10,37 +10,27 @@ interface Count {
   [count: number]: number;
 }
 
-interface Counts {
-  [questionId: number]: number[];
-}
-
 interface CountMap {
   [questionId: number]: Count;
 }
 
 interface KeywordsStore {
   keywords: Keywords;
-  counts: Counts;
   countMap: CountMap;
+
   upsertKeyword: (targetKeyword: KeywordInfo) => void;
   deleteKeyword: (targetKeyword: { questionId: number; keyword: string }) => void;
 }
 
-function appendArrayUnique<T>(array: T[], element: T): T[] {
-  if (!array.includes(element)) return [...array, element];
-  return array;
-}
-
-function syncCountMap(array: number[], countMap: Count, element: number): Count {
-  if (!array.includes(element)) {
-    return { ...countMap, [element]: 1 };
+function syncCountMap(countMap: Count, count: number): Count {
+  if (!Object.keys(countMap).includes(count.toString())) {
+    return { ...countMap, [count]: 1 };
   }
   return countMap;
 }
 
 function appendKeyword(
   keywords: Keywords,
-  counts: Counts,
   countMap: CountMap,
   newKeywordData: { questionId: number; keyword: string; count: number }
 ) {
@@ -50,14 +40,12 @@ function appendKeyword(
       ...keywords,
       [questionId]: [...(keywords[questionId] || []), { keyword, count: 1 }]
     },
-    counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], 1) },
-    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, 1) }
+    countMap: { ...countMap, [questionId]: syncCountMap(countMap[questionId] || {}, 1) }
   };
 }
 
 function modifyKeywordCount(
   keywords: Keywords,
-  counts: Counts,
   countMap: CountMap,
   targetKeyword: { questionId: number; keyword: string; count: number }
 ) {
@@ -73,42 +61,26 @@ function modifyKeywordCount(
       ...keywords,
       [questionId]: sortedKeywords
     },
-    counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], count).sort((a, b) => b - a) },
-    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, count) }
+    countMap: { ...countMap, [questionId]: syncCountMap(countMap[questionId] || {}, count) }
   };
 }
 
 export const useKeywordsStore = create<KeywordsStore>((set) => ({
   keywords: {
-    1: [
-      { keyword: '김치찌개', count: 1 },
-      { keyword: '떡볶이', count: 1 },
-      { keyword: '제육볶음', count: 1 },
-      { keyword: '미역국', count: 1 },
-      { keyword: '삼계탕', count: 1 }
-    ],
-    2: [
-      { keyword: '만두전골', count: 1 },
-      { keyword: '비빔밥', count: 1 },
-      { keyword: '불고기', count: 1 },
-      { keyword: '닭칼국수다 어쩔래어쩔어쩔', count: 1 },
-      { keyword: '장충동왕족발보쌈', count: 1 },
-      { keyword: '찜닭', count: 1 },
-      { keyword: '갈비탕', count: 1 }
-    ],
+    1: [],
+    2: [],
     3: [],
     4: [],
     5: []
   },
-  counts: { 1: [1] },
-  countMap: { 1: { 1: 5 } },
+  countMap: {},
 
   upsertKeyword: (targetKeyword) => {
     set((state) => {
       const { questionId, keyword } = targetKeyword;
       if (state.keywords[questionId].some((element) => element.keyword === keyword))
-        return modifyKeywordCount(state.keywords, state.counts, state.countMap, targetKeyword);
-      return appendKeyword(state.keywords, state.counts, state.countMap, targetKeyword);
+        return modifyKeywordCount(state.keywords, state.countMap, targetKeyword);
+      return appendKeyword(state.keywords, state.countMap, targetKeyword);
     });
   },
 

--- a/frontend/src/stores/keywords.ts
+++ b/frontend/src/stores/keywords.ts
@@ -2,14 +2,6 @@ import { create } from 'zustand';
 
 import { Keyword, KeywordInfo } from '@/types';
 
-interface KeywordMapElement {
-  [keyword: string]: { count: number; index: number };
-}
-
-interface KeywordsMap {
-  [questionId: number]: KeywordMapElement;
-}
-
 interface Keywords {
   [questionId: number]: Keyword[];
 }
@@ -28,7 +20,6 @@ interface CountMap {
 
 interface KeywordsStore {
   keywords: Keywords;
-  keywordsMap: KeywordsMap;
   counts: Counts;
   countMap: CountMap;
   upsertKeyword: (targetKeyword: KeywordInfo) => void;
@@ -48,64 +39,42 @@ function syncCountMap(array: number[], countMap: Count, element: number): Count 
 }
 
 function appendKeyword(
-  keywordsMap: KeywordsMap,
   keywords: Keywords,
   counts: Counts,
   countMap: CountMap,
   newKeywordData: { questionId: number; keyword: string; count: number }
 ) {
   const { questionId, keyword } = newKeywordData;
-  const prevLength = keywords[questionId]?.length ?? 0;
   return {
     keywords: {
       ...keywords,
       [questionId]: [...(keywords[questionId] || []), { keyword, count: 1 }]
     },
     counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], 1) },
-    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, 1) },
-    keywordsMap: {
-      ...keywordsMap,
-      [questionId]: {
-        ...(keywordsMap[questionId] || {}),
-        [keyword]: { count: 1, index: prevLength }
-      }
-    }
+    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, 1) }
   };
 }
 
 function modifyKeywordCount(
-  keywordsMap: KeywordsMap,
   keywords: Keywords,
   counts: Counts,
   countMap: CountMap,
   targetKeyword: { questionId: number; keyword: string; count: number }
 ) {
   const { questionId, keyword, count } = targetKeyword;
-  const modifiedKeywordsMapElement = {
-    ...(keywordsMap[questionId] || {}),
-    [keyword]: { count, index: 0 }
-  };
 
-  const modifiedKeywordsElement = [...keywords[questionId]].sort(
-    (a, b) => modifiedKeywordsMapElement[b.keyword].count - modifiedKeywordsMapElement[a.keyword].count
+  const modifiedKeywords = keywords[questionId].map((element) =>
+    element.keyword === keyword ? { ...element, count: count } : element
   );
-
-  modifiedKeywordsElement.forEach((keyword, index) => {
-    const key = keyword.keyword;
-    modifiedKeywordsMapElement[key].index = index;
-  });
+  const sortedKeywords = modifiedKeywords.sort((a, b) => b.count - a.count);
 
   return {
     keywords: {
       ...keywords,
-      [questionId]: modifiedKeywordsElement
+      [questionId]: sortedKeywords
     },
     counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], count).sort((a, b) => b - a) },
-    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, count) },
-    keywordsMap: {
-      ...keywordsMap,
-      [questionId]: modifiedKeywordsMapElement
-    }
+    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, count) }
   };
 }
 
@@ -133,34 +102,13 @@ export const useKeywordsStore = create<KeywordsStore>((set) => ({
   },
   counts: { 1: [1] },
   countMap: { 1: { 1: 5 } },
-  keywordsMap: {
-    1: {
-      김치찌개: { count: 5, index: 0 },
-      떡볶이: { count: 4, index: 1 },
-      제육볶음: { count: 3, index: 2 },
-      미역국: { count: 2, index: 3 },
-      삼계탕: { count: 1, index: 4 }
-    },
-    2: {
-      만두전골: { count: 7, index: 0 },
-      비빔밥: { count: 6, index: 1 },
-      불고기: { count: 5, index: 2 },
-      '닭칼국수다 어쩔래어쩔어쩔': { count: 4, index: 3 },
-      장충동왕족발보쌈: { count: 3, index: 4 },
-      찜닭: { count: 2, index: 5 },
-      갈비탕: { count: 1, index: 6 }
-    },
-    3: {},
-    4: {},
-    5: {}
-  },
 
   upsertKeyword: (targetKeyword) => {
     set((state) => {
       const { questionId, keyword } = targetKeyword;
-      if (state.keywordsMap[questionId] && state.keywordsMap[questionId][keyword])
-        return modifyKeywordCount(state.keywordsMap, state.keywords, state.counts, state.countMap, targetKeyword);
-      return appendKeyword(state.keywordsMap, state.keywords, state.counts, state.countMap, targetKeyword);
+      if (state.keywords[questionId].some((element) => element.keyword === keyword))
+        return modifyKeywordCount(state.keywords, state.counts, state.countMap, targetKeyword);
+      return appendKeyword(state.keywords, state.counts, state.countMap, targetKeyword);
     });
   },
 

--- a/frontend/src/styles/index.ts
+++ b/frontend/src/styles/index.ts
@@ -1,3 +1,4 @@
 export { rotate, growAndShrink, hoverGrowJumpAnimation, fadeIn, fadeOut } from './animation';
 export { flexStyle } from './flex';
 export { Variables } from './Variables';
+export { keywordStyleMap } from './keywordStyleMap';

--- a/frontend/src/styles/keywordStyleMap.ts
+++ b/frontend/src/styles/keywordStyleMap.ts
@@ -1,0 +1,50 @@
+import { Group } from '@/types';
+import { css, SerializedStyles } from '@emotion/react';
+import { Variables } from './Variables';
+
+type KeywordStyleMap = (selected: boolean) => Record<Group, SerializedStyles>;
+
+export const keywordStyleMap: KeywordStyleMap = (selected: boolean) => {
+  const borderStyle = (color: string, selected: boolean) => ({
+    border: selected ? `solid 0.25rem ${color}` : 'none'
+  });
+
+  return {
+    Big: css(
+      {
+        font: Variables.typography.font_bold_48,
+        color: Variables.colors.text_word_strong,
+        backgroundColor: Variables.colors.surface_word_strong,
+        borderRadius: '2rem'
+      },
+      borderStyle(Variables.colors.text_word_strong, selected)
+    ),
+    Medium: css(
+      {
+        font: Variables.typography.font_bold_36,
+        color: Variables.colors.text_word_medium,
+        backgroundColor: Variables.colors.surface_word_medium,
+        borderRadius: '1.5rem'
+      },
+      borderStyle(Variables.colors.text_word_medium, selected)
+    ),
+    Small: css(
+      {
+        font: Variables.typography.font_bold_24,
+        color: Variables.colors.text_word_weak,
+        backgroundColor: Variables.colors.surface_word_weak,
+        borderRadius: '1.25rem'
+      },
+      borderStyle(Variables.colors.text_word_weak, selected)
+    ),
+    Tiny: css(
+      {
+        font: Variables.typography.font_bold_16,
+        color: Variables.colors.text_weak,
+        backgroundColor: Variables.colors.surface_word_default,
+        borderRadius: '1rem'
+      },
+      borderStyle(Variables.colors.text_weak, selected)
+    )
+  };
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 export type { ToastType, Position, ToastProps, ToastOption } from './toast';
 export type { Question } from './question';
-export type { Group, Keyword, KeywordInfo } from './keyword';
+export type { Group, Keyword, KeywordInfo, Keywords, PrefixSum, PrefixSumMap } from './keyword';
 export type { Participant } from './participant';
 export type { ParticipantItem } from './ParticipantItem';
 export type { KeywordResponse } from './response';

--- a/frontend/src/types/keyword.ts
+++ b/frontend/src/types/keyword.ts
@@ -5,6 +5,18 @@ export interface Keyword {
   count: number;
 }
 
+export interface Keywords {
+  [questionId: number]: Keyword[];
+}
+
+export interface PrefixSum {
+  [count: number]: number;
+}
+
+export interface PrefixSumMap {
+  [questionId: number]: PrefixSum;
+}
+
 export interface KeywordInfo {
   questionId: number;
   keyword: string;


### PR DESCRIPTION
# ✅ 주요 작업
- [x] 누적합 기반으로 현재 키워드가 상위 몇 %인지 판별하는 로직 작성
  - keyword store 리팩토링
- [x] 그룹에 따른 스타일 / 애니메이션 임시 적용

### 작업 결과
![임시로 그룹에 따른 스타일 및 애니메이션 적용](https://github.com/user-attachments/assets/7a67e2ab-9a6e-4130-bac7-7cebe0b10139)

- 임시로 그룹에 따른 스타일 / 애니메이션을 적용해본 결과입니다.

# 📚 학습 키워드
누적 합, zustand, animation

# 💭 고민과 해결과정
### 누적합 기반으로 현재 키워드가 상위 몇 %인지 판별하는 로직
정렬만 진행하고 index 기반으로 그룹을 나눌 경우, 같은 count인데도 index가 달라 다른 그룹으로 나뉘는 문제가 발생합니다. 

이를 해결하기 위해 키워드 이벤트를 받아 store를 수정할 때, `{ [count] : [해당 count까지 포함해서 총 몇 개의 요소가 있는지 누적합] }` 도 저장하도록 작성하였습니다.
- 각 keyword의 그룹을 판별할 때, keyword.count를 통해 누적합 map에 접근함으로써 상위 몇 %인지 바로 파악할 수 있습니다.
- 예를 들어 


> [ {keyword: '치킨', count: 2},  {keyword: '펩제라', count: 2}, {keyword: '불닭볶음면', count: 2}, {keyword: '파전', count: 1}, {keyword: '피자', count: 1}, {keyword: '민트초코', count: 1}, {keyword: '그릭요거트', count: 1}, {keyword: '사이다', count: 1} ]


와 같은 키워드들이 있을 때, 누적합 map에는 `{ 2 :  3, 1 :  8}`이 저장됩니다. `count: 1`인 키워드들은 모두 `상위 8/8 * 100 = 100%`이므로 올바르게 가장 작은 그룹으로 판별되며, `count: 2`인 키워드들은 모두 `상위 3/8 * 100 = 37.5%`이므로 올바르게 큰 그룹으로 판별됩니다.

### 애니메이션
`transition`의 속성으로 `font-size`도 지정할 수 있다는 걸 알게 되어 적용했습니다. font-size의 변화로 인한 크기 변화도 애니메이션이 적용되어서 간편한 것 같습니다.


# 📌 이슈 사항
- 스타일을 테스트용으로 추가하였으나 추후 word cloud 구현 방법이 구체화되면 변경될 가능성이 높습니다!
- weight가 아니라 그룹 기반으로 할 때 조금 어색한 것 같다는 생각이 듭니다. 조금 더 테스트해볼 필요가 있을 것 같습니다