### PR TITLE
워드 클라우드 UI 레이아웃 및 애니메이션 구현

### DIFF
--- a/frontend/src/components/QuestionInput.tsx
+++ b/frontend/src/components/QuestionInput.tsx
@@ -39,7 +39,6 @@ const QuestionInput = ({ currentQuestionIndex }: QuestionInputProps) => {
 
     if (socket && socket.connected) {
       socket.emit('keyword:pick', { questionId: currentQuestionIndex + 1, keyword }, (response: KeywordResponse) => {
-        console.log(response);
         if (response.status !== 'pick') {
           /*
             TODO: 추후 서버 로직에서 status가 ok로 바뀐다면 수정 필요

--- a/frontend/src/components/RoomCreateButton.tsx
+++ b/frontend/src/components/RoomCreateButton.tsx
@@ -31,7 +31,6 @@ const RoomCreateButton = () => {
   const createRoom = async () => {
     try {
       setLoading(true);
-      console.log(config.SOCKET_SERVER_URL);
       const response = await fetch(`${config.SOCKET_SERVER_URL}/rooms`, {
         method: 'POST',
         headers: {

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -2,3 +2,7 @@ export const MIN_SHORT_RADIUS = 210; //반지름
 export const MIN_LONG_RADIUS = Math.floor((MIN_SHORT_RADIUS * 4) / 3); //장축:단축 = 4:3
 export const MAX_SHORT_RADIUS = 240;
 export const MAX_LONG_RADIUS = Math.floor((MAX_SHORT_RADIUS * 4) / 3);
+
+export const BIG_THRESHOLD = 20;
+export const MIDEIUM_THRESHOLD = 40;
+export const SMALL_THRESHOLD = 60;

--- a/frontend/src/pages/room/KeywordsView.tsx
+++ b/frontend/src/pages/room/KeywordsView.tsx
@@ -1,30 +1,54 @@
 import { css } from '@emotion/react';
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { useSocketStore } from '@/stores';
 import { useKeywordsStore } from '@/stores/keywords';
-import { keywordStyleMap, Variables } from '@/styles';
-import { Group, Keyword, PrefixSum } from '@/types';
+import { keywordStyleMap, scaleIn, Variables } from '@/styles';
+import { Group, Keyword, KeywordsCoordinates, PrefixSum } from '@/types';
 import { BIG_THRESHOLD, MIDEIUM_THRESHOLD, SMALL_THRESHOLD } from '@/constants';
 
-const KeywordsContainer = css`
+const KeywordsViewContainer = css`
   width: 100%;
+  height: 400px;
   margin-top: 50px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 8px;
+  position: relative;
+`;
+
+// 좌표 계산을 위한 보이지 않는 컨테이너
+const HiddenKeywordsContainer = css`
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  border: 1px solid black;
+  position: absolute;
+  overflow: hidden;
+  opacity: 0%;
+  z-index: 1;
+`;
+
+const RealKeywordsContainer = css`
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  overflow: hidden;
+  opacity: 100%;
+  z-index: 2;
 `;
 
 const KeywordStyle = css`
+  position: absolute;
   border: 1px solid black;
   height: fit-content;
   padding: 0.5rem 0.75rem;
   background: ${Variables.colors.surface_word_default};
   text-align: center;
   min-width: 60px;
-  transition: font-size 0.3s ease;
+  transition: all 0.3s ease;
+  transform: scale(0); // 초기 스케일 값 0
+  animation: ${scaleIn} 0.3s forwards; // keyframes 애니메이션 호출
 `;
 
 interface KeywordsViewProps {
@@ -49,6 +73,8 @@ function getKeywordGroup(keyword: Keyword, keywordCountSum: number, prefixSum: P
 const KeywordsView = ({ questionId }: KeywordsViewProps) => {
   const { socket } = useSocketStore();
   const { keywords, prefixSumMap, upsertKeyword } = useKeywordsStore();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [keywordsCoordinates, setKeywordsCoordinates] = useState<KeywordsCoordinates>({});
 
   useEffect(() => {
     if (socket) {
@@ -64,21 +90,153 @@ const KeywordsView = ({ questionId }: KeywordsViewProps) => {
     };
   }, [socket]);
 
+  // 키워드 배열 업데이트될 때마다 워드 클라우드 그리기
+  useEffect(() => {
+    const container = containerRef.current;
+    const wordArray = keywords[questionId] || [];
+    if (!container || wordArray.length === 0) return;
+
+    // 컨테이너 초기화
+    container.innerHTML = '';
+
+    const containerWidth = container.offsetWidth;
+    const containerHeight = container.offsetHeight;
+    const containerCenterX = containerWidth / 2.0;
+    const containerCenterY = containerHeight / 2.0;
+    const containerAspectRatio = containerWidth / containerHeight;
+
+    const hitTest = (elem: HTMLElement, other_elems: HTMLElement[]): boolean => {
+      const overlapTest = (a: HTMLElement, b: HTMLElement, gap: number) => {
+        if (
+          Math.abs(a.offsetLeft + a.offsetWidth / 2 - b.offsetLeft - b.offsetWidth / 2) <
+          a.offsetWidth / 2 + b.offsetWidth / 2 + gap
+        ) {
+          if (
+            Math.abs(a.offsetTop + a.offsetHeight / 2 - b.offsetTop - b.offsetHeight / 2) <
+            a.offsetHeight / 2 + b.offsetHeight / 2 + gap
+          ) {
+            return true;
+          }
+        } else {
+          return false;
+        }
+      };
+
+      let i = 0;
+      for (i = 0; i < other_elems.length; i++) {
+        if (overlapTest(elem, other_elems[i], 4)) return true;
+      }
+      return false;
+    };
+
+    const alreadyPlacedWords: HTMLElement[] = [];
+
+    const drawOneWord = (index: number, word: Keyword) => {
+      let wordId = `word-${index}`;
+      let angle = Math.random() * Math.PI * 2;
+      let radius = 0.0;
+      const step = 2.0;
+      let weight = 1;
+      let customClass = '';
+      let innerHTML = '';
+      let wordSpan: HTMLSpanElement = document.createElement('span');
+
+      wordSpan.setAttribute('id', wordId);
+
+      if (wordArray[0].count > wordArray[wordArray.length - 1].count) {
+        weight =
+          Math.round(
+            ((word.count - wordArray[wordArray.length - 1].count) /
+              (wordArray[0].count - wordArray[wordArray.length - 1].count)) *
+              3
+          ) + 1;
+      }
+      wordSpan.innerHTML = word.keyword;
+
+      // TODO: 클릭 핸들러 붙이기
+      wordSpan.addEventListener('click', () => {});
+
+      let width = wordSpan.offsetWidth;
+      let height = wordSpan.offsetHeight;
+      let left = containerCenterX - width / 2;
+      let top = containerCenterY - height / 2;
+
+      const wordSpanStyle = `
+        position: absolute;
+        left: ${left}px;
+        top: ${top}px;
+        border: 1px solid black;
+        font-size: ${weight < 2 ? 16 : weight * 12}px;
+        padding: 0.35rem 0.75rem;
+        background: ${Variables.colors.surface_word_default};
+        text-align: center;
+        min-width: 60px;
+        transition: font-size 0.3s ease;
+      `;
+
+      wordSpan.style.cssText = wordSpanStyle;
+      container.appendChild(wordSpan);
+
+      while (hitTest(wordSpan, alreadyPlacedWords)) {
+        radius += step;
+        angle += (index % 2 === 0 ? 1 : -1) * step;
+        left = containerCenterX - width / 2 + radius * Math.cos(angle) * containerAspectRatio;
+        top = containerCenterY + radius * Math.sin(angle) - height / 2.0;
+        wordSpan.style.left = `${left}px`;
+        wordSpan.style.top = `${top}px`;
+      }
+
+      // 컨테이너를 벗어나는 단어는 제거
+      if (left < 0 || top < 0 || left + width > containerWidth || top + height > containerHeight) {
+        container.removeChild(wordSpan);
+        return;
+      }
+
+      // 첫번째 키워드를 정중앙에 위치시키기 위해 조정
+      if (index === 0) {
+        left -= wordSpan.offsetWidth / 2;
+        top -= wordSpan.offsetHeight / 2;
+        wordSpan.style.left = `${left}px`;
+        wordSpan.style.top = `${top}px`;
+      }
+
+      alreadyPlacedWords.push(wordSpan);
+      setKeywordsCoordinates((prev) => ({
+        ...prev,
+        [word.keyword]: { x: left, y: top, count: word.count }
+      }));
+    };
+
+    wordArray.forEach((word, index) => {
+      drawOneWord(index, word);
+    });
+  }, [keywords[questionId]]);
+
   return (
-    <div css={KeywordsContainer}>
-      {keywords[questionId]?.map((keywordObject) => (
-        <div
-          key={`${questionId}-${keywordObject.keyword}`}
-          css={[
-            KeywordStyle,
-            keywordStyleMap(false)[
-              getKeywordGroup(keywordObject, keywords[questionId].length, prefixSumMap[questionId])
-            ]
-          ]}
-        >
-          {keywordObject.keyword}
-        </div>
-      ))}
+    <div css={KeywordsViewContainer}>
+      <div css={HiddenKeywordsContainer} ref={containerRef}></div>
+      <div css={RealKeywordsContainer}>
+        {Object.keys(keywordsCoordinates).map((keyword) => {
+          const keywordObject: Keyword = { keyword, count: keywordsCoordinates[keyword].count };
+          return (
+            <div
+              key={`${questionId}-${keywordObject.keyword}`}
+              css={[
+                KeywordStyle,
+                keywordStyleMap(false)[
+                  getKeywordGroup(keywordObject, Object.keys(keywordsCoordinates).length, prefixSumMap[questionId])
+                ],
+                {
+                  left: keywordsCoordinates[keyword].x,
+                  top: keywordsCoordinates[keyword].y
+                }
+              ]}
+            >
+              {keywordObject.keyword}
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/frontend/src/pages/room/KeywordsView.tsx
+++ b/frontend/src/pages/room/KeywordsView.tsx
@@ -3,45 +3,79 @@ import { useEffect } from 'react';
 
 import { useSocketStore } from '@/stores';
 import { useKeywordsStore } from '@/stores/keywords';
-import { Variables } from '@/styles';
+import { keywordStyleMap, Variables } from '@/styles';
+import { Group, Keyword, PrefixSum } from '@/types';
+import { BIG_THRESHOLD, MIDEIUM_THRESHOLD, SMALL_THRESHOLD } from '@/constants';
 
 const KeywordsContainer = css`
   width: 100%;
   margin-top: 50px;
   display: flex;
   justify-content: center;
+  align-items: center;
   flex-wrap: wrap;
   gap: 8px;
 `;
+
 const KeywordStyle = css`
   border: 1px solid black;
-  padding: 3px 10px;
+  height: fit-content;
+  padding: 0.5rem 0.75rem;
   background: ${Variables.colors.surface_word_default};
-  border-radius: 50px;
   text-align: center;
   min-width: 60px;
+  transition: font-size 0.3s ease;
 `;
 
 interface KeywordsViewProps {
   questionId: number;
 }
 
+function getKeywordGroup(keyword: Keyword, keywordCountSum: number, prefixSum: PrefixSum): Group {
+  const { count } = keyword;
+  const curPrefixSum = prefixSum[count];
+  const ratio = Math.ceil((curPrefixSum / keywordCountSum) * 100);
+
+  if (ratio < BIG_THRESHOLD) {
+    return 'Big';
+  } else if (ratio < MIDEIUM_THRESHOLD) {
+    return 'Medium';
+  } else if (ratio < SMALL_THRESHOLD) {
+    return 'Small';
+  }
+  return 'Tiny';
+}
+
 const KeywordsView = ({ questionId }: KeywordsViewProps) => {
   const { socket } = useSocketStore();
-  const { keywords, upsertKeyword } = useKeywordsStore();
+  const { keywords, prefixSumMap, upsertKeyword } = useKeywordsStore();
 
   useEffect(() => {
     if (socket) {
+      socket.off('empathy:keyword:count');
+
       socket.on('empathy:keyword:count', (response: { questionId: number; keyword: string; count: number }) => {
         upsertKeyword(response);
       });
     }
+
+    return () => {
+      socket?.off('empathy:keyword:count');
+    };
   }, [socket]);
 
   return (
     <div css={KeywordsContainer}>
       {keywords[questionId]?.map((keywordObject) => (
-        <div key={`${questionId}-${keywordObject.keyword}`} css={KeywordStyle}>
+        <div
+          key={`${questionId}-${keywordObject.keyword}`}
+          css={[
+            KeywordStyle,
+            keywordStyleMap(false)[
+              getKeywordGroup(keywordObject, keywords[questionId].length, prefixSumMap[questionId])
+            ]
+          ]}
+        >
           {keywordObject.keyword}
         </div>
       ))}

--- a/frontend/src/pages/room/questionsView.tsx
+++ b/frontend/src/pages/room/questionsView.tsx
@@ -86,8 +86,8 @@ const QuestionsView = ({ onQuestionStart }: QuestionViewProps) => {
         onQuestionStart();
         if (response.questions.length > 0) {
           const firstQuestionTimeLeft = getRemainingSeconds(new Date(response.questions[0].expirationTime), new Date());
-          setTimeLeft(300);
-          setInitialTimeLeft(300);
+          setTimeLeft(3000);
+          setInitialTimeLeft(3000);
         }
       });
     }

--- a/frontend/src/stores/keywords.ts
+++ b/frontend/src/stores/keywords.ts
@@ -10,37 +10,27 @@ interface Count {
   [count: number]: number;
 }
 
-interface Counts {
-  [questionId: number]: number[];
-}
-
 interface CountMap {
   [questionId: number]: Count;
 }
 
 interface KeywordsStore {
   keywords: Keywords;
-  counts: Counts;
   countMap: CountMap;
+
   upsertKeyword: (targetKeyword: KeywordInfo) => void;
   deleteKeyword: (targetKeyword: { questionId: number; keyword: string }) => void;
 }
 
-function appendArrayUnique<T>(array: T[], element: T): T[] {
-  if (!array.includes(element)) return [...array, element];
-  return array;
-}
-
-function syncCountMap(array: number[], countMap: Count, element: number): Count {
-  if (!array.includes(element)) {
-    return { ...countMap, [element]: 1 };
+function syncCountMap(countMap: Count, count: number): Count {
+  if (!Object.keys(countMap).includes(count.toString())) {
+    return { ...countMap, [count]: 1 };
   }
   return countMap;
 }
 
 function appendKeyword(
   keywords: Keywords,
-  counts: Counts,
   countMap: CountMap,
   newKeywordData: { questionId: number; keyword: string; count: number }
 ) {
@@ -50,14 +40,12 @@ function appendKeyword(
       ...keywords,
       [questionId]: [...(keywords[questionId] || []), { keyword, count: 1 }]
     },
-    counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], 1) },
-    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, 1) }
+    countMap: { ...countMap, [questionId]: syncCountMap(countMap[questionId] || {}, 1) }
   };
 }
 
 function modifyKeywordCount(
   keywords: Keywords,
-  counts: Counts,
   countMap: CountMap,
   targetKeyword: { questionId: number; keyword: string; count: number }
 ) {
@@ -73,42 +61,26 @@ function modifyKeywordCount(
       ...keywords,
       [questionId]: sortedKeywords
     },
-    counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], count).sort((a, b) => b - a) },
-    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, count) }
+    countMap: { ...countMap, [questionId]: syncCountMap(countMap[questionId] || {}, count) }
   };
 }
 
 export const useKeywordsStore = create<KeywordsStore>((set) => ({
   keywords: {
-    1: [
-      { keyword: '김치찌개', count: 1 },
-      { keyword: '떡볶이', count: 1 },
-      { keyword: '제육볶음', count: 1 },
-      { keyword: '미역국', count: 1 },
-      { keyword: '삼계탕', count: 1 }
-    ],
-    2: [
-      { keyword: '만두전골', count: 1 },
-      { keyword: '비빔밥', count: 1 },
-      { keyword: '불고기', count: 1 },
-      { keyword: '닭칼국수다 어쩔래어쩔어쩔', count: 1 },
-      { keyword: '장충동왕족발보쌈', count: 1 },
-      { keyword: '찜닭', count: 1 },
-      { keyword: '갈비탕', count: 1 }
-    ],
+    1: [],
+    2: [],
     3: [],
     4: [],
     5: []
   },
-  counts: { 1: [1] },
-  countMap: { 1: { 1: 5 } },
+  countMap: {},
 
   upsertKeyword: (targetKeyword) => {
     set((state) => {
       const { questionId, keyword } = targetKeyword;
       if (state.keywords[questionId].some((element) => element.keyword === keyword))
-        return modifyKeywordCount(state.keywords, state.counts, state.countMap, targetKeyword);
-      return appendKeyword(state.keywords, state.counts, state.countMap, targetKeyword);
+        return modifyKeywordCount(state.keywords, state.countMap, targetKeyword);
+      return appendKeyword(state.keywords, state.countMap, targetKeyword);
     });
   },
 

--- a/frontend/src/stores/keywords.ts
+++ b/frontend/src/stores/keywords.ts
@@ -2,14 +2,6 @@ import { create } from 'zustand';
 
 import { Keyword, KeywordInfo } from '@/types';
 
-interface KeywordMapElement {
-  [keyword: string]: { count: number; index: number };
-}
-
-interface KeywordsMap {
-  [questionId: number]: KeywordMapElement;
-}
-
 interface Keywords {
   [questionId: number]: Keyword[];
 }
@@ -28,7 +20,6 @@ interface CountMap {
 
 interface KeywordsStore {
   keywords: Keywords;
-  keywordsMap: KeywordsMap;
   counts: Counts;
   countMap: CountMap;
   upsertKeyword: (targetKeyword: KeywordInfo) => void;
@@ -48,64 +39,42 @@ function syncCountMap(array: number[], countMap: Count, element: number): Count 
 }
 
 function appendKeyword(
-  keywordsMap: KeywordsMap,
   keywords: Keywords,
   counts: Counts,
   countMap: CountMap,
   newKeywordData: { questionId: number; keyword: string; count: number }
 ) {
   const { questionId, keyword } = newKeywordData;
-  const prevLength = keywords[questionId]?.length ?? 0;
   return {
     keywords: {
       ...keywords,
       [questionId]: [...(keywords[questionId] || []), { keyword, count: 1 }]
     },
     counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], 1) },
-    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, 1) },
-    keywordsMap: {
-      ...keywordsMap,
-      [questionId]: {
-        ...(keywordsMap[questionId] || {}),
-        [keyword]: { count: 1, index: prevLength }
-      }
-    }
+    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, 1) }
   };
 }
 
 function modifyKeywordCount(
-  keywordsMap: KeywordsMap,
   keywords: Keywords,
   counts: Counts,
   countMap: CountMap,
   targetKeyword: { questionId: number; keyword: string; count: number }
 ) {
   const { questionId, keyword, count } = targetKeyword;
-  const modifiedKeywordsMapElement = {
-    ...(keywordsMap[questionId] || {}),
-    [keyword]: { count, index: 0 }
-  };
 
-  const modifiedKeywordsElement = [...keywords[questionId]].sort(
-    (a, b) => modifiedKeywordsMapElement[b.keyword].count - modifiedKeywordsMapElement[a.keyword].count
+  const modifiedKeywords = keywords[questionId].map((element) =>
+    element.keyword === keyword ? { ...element, count: count } : element
   );
-
-  modifiedKeywordsElement.forEach((keyword, index) => {
-    const key = keyword.keyword;
-    modifiedKeywordsMapElement[key].index = index;
-  });
+  const sortedKeywords = modifiedKeywords.sort((a, b) => b.count - a.count);
 
   return {
     keywords: {
       ...keywords,
-      [questionId]: modifiedKeywordsElement
+      [questionId]: sortedKeywords
     },
     counts: { ...counts, [questionId]: appendArrayUnique(counts[questionId] || [], count).sort((a, b) => b - a) },
-    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, count) },
-    keywordsMap: {
-      ...keywordsMap,
-      [questionId]: modifiedKeywordsMapElement
-    }
+    countMap: { ...countMap, [questionId]: syncCountMap(counts[questionId] || [], countMap[questionId] || {}, count) }
   };
 }
 
@@ -133,34 +102,13 @@ export const useKeywordsStore = create<KeywordsStore>((set) => ({
   },
   counts: { 1: [1] },
   countMap: { 1: { 1: 5 } },
-  keywordsMap: {
-    1: {
-      김치찌개: { count: 5, index: 0 },
-      떡볶이: { count: 4, index: 1 },
-      제육볶음: { count: 3, index: 2 },
-      미역국: { count: 2, index: 3 },
-      삼계탕: { count: 1, index: 4 }
-    },
-    2: {
-      만두전골: { count: 7, index: 0 },
-      비빔밥: { count: 6, index: 1 },
-      불고기: { count: 5, index: 2 },
-      '닭칼국수다 어쩔래어쩔어쩔': { count: 4, index: 3 },
-      장충동왕족발보쌈: { count: 3, index: 4 },
-      찜닭: { count: 2, index: 5 },
-      갈비탕: { count: 1, index: 6 }
-    },
-    3: {},
-    4: {},
-    5: {}
-  },
 
   upsertKeyword: (targetKeyword) => {
     set((state) => {
       const { questionId, keyword } = targetKeyword;
-      if (state.keywordsMap[questionId] && state.keywordsMap[questionId][keyword])
-        return modifyKeywordCount(state.keywordsMap, state.keywords, state.counts, state.countMap, targetKeyword);
-      return appendKeyword(state.keywordsMap, state.keywords, state.counts, state.countMap, targetKeyword);
+      if (state.keywords[questionId].some((element) => element.keyword === keyword))
+        return modifyKeywordCount(state.keywords, state.counts, state.countMap, targetKeyword);
+      return appendKeyword(state.keywords, state.counts, state.countMap, targetKeyword);
     });
   },
 

--- a/frontend/src/styles/animation.ts
+++ b/frontend/src/styles/animation.ts
@@ -64,3 +64,12 @@ export const fadeOut = keyframes({
   from: { opacity: 1 },
   to: { opacity: 0 }
 });
+
+export const scaleIn = keyframes({
+  from: {
+    transform: 'scale(0)' // 애니메이션 시작 시 크기 0
+  },
+  to: {
+    transform: 'scale(1)' // 애니메이션 끝날 때 크기 1
+  }
+});

--- a/frontend/src/styles/index.ts
+++ b/frontend/src/styles/index.ts
@@ -1,3 +1,4 @@
 export { rotate, growAndShrink, hoverGrowJumpAnimation, fadeIn, fadeOut } from './animation';
 export { flexStyle } from './flex';
 export { Variables } from './Variables';
+export { keywordStyleMap } from './keywordStyleMap';

--- a/frontend/src/styles/index.ts
+++ b/frontend/src/styles/index.ts
@@ -1,4 +1,4 @@
-export { rotate, growAndShrink, hoverGrowJumpAnimation, fadeIn, fadeOut } from './animation';
+export { rotate, growAndShrink, hoverGrowJumpAnimation, fadeIn, fadeOut, scaleIn } from './animation';
 export { flexStyle } from './flex';
 export { Variables } from './Variables';
 export { keywordStyleMap } from './keywordStyleMap';

--- a/frontend/src/styles/keywordStyleMap.ts
+++ b/frontend/src/styles/keywordStyleMap.ts
@@ -1,0 +1,50 @@
+import { Group } from '@/types';
+import { css, SerializedStyles } from '@emotion/react';
+import { Variables } from './Variables';
+
+type KeywordStyleMap = (selected: boolean) => Record<Group, SerializedStyles>;
+
+export const keywordStyleMap: KeywordStyleMap = (selected: boolean) => {
+  const borderStyle = (color: string, selected: boolean) => ({
+    border: selected ? `solid 0.25rem ${color}` : 'none'
+  });
+
+  return {
+    Big: css(
+      {
+        font: Variables.typography.font_bold_48,
+        color: Variables.colors.text_word_strong,
+        backgroundColor: Variables.colors.surface_word_strong,
+        borderRadius: '2rem'
+      },
+      borderStyle(Variables.colors.text_word_strong, selected)
+    ),
+    Medium: css(
+      {
+        font: Variables.typography.font_bold_36,
+        color: Variables.colors.text_word_medium,
+        backgroundColor: Variables.colors.surface_word_medium,
+        borderRadius: '1.5rem'
+      },
+      borderStyle(Variables.colors.text_word_medium, selected)
+    ),
+    Small: css(
+      {
+        font: Variables.typography.font_bold_24,
+        color: Variables.colors.text_word_weak,
+        backgroundColor: Variables.colors.surface_word_weak,
+        borderRadius: '1.25rem'
+      },
+      borderStyle(Variables.colors.text_word_weak, selected)
+    ),
+    Tiny: css(
+      {
+        font: Variables.typography.font_bold_16,
+        color: Variables.colors.text_weak,
+        backgroundColor: Variables.colors.surface_word_default,
+        borderRadius: '1rem'
+      },
+      borderStyle(Variables.colors.text_weak, selected)
+    )
+  };
+};

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 export type { ToastType, Position, ToastProps, ToastOption } from './toast';
 export type { Question } from './question';
-export type { Group, Keyword, KeywordInfo, Keywords, PrefixSum, PrefixSumMap } from './keyword';
+export type { Group, Keyword, KeywordInfo, Keywords, PrefixSum, PrefixSumMap, KeywordsCoordinates } from './keyword';
 export type { Participant } from './participant';
 export type { ParticipantItem } from './ParticipantItem';
 export type { KeywordResponse } from './response';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,6 +1,6 @@
 export type { ToastType, Position, ToastProps, ToastOption } from './toast';
 export type { Question } from './question';
-export type { Group, Keyword, KeywordInfo } from './keyword';
+export type { Group, Keyword, KeywordInfo, Keywords, PrefixSum, PrefixSumMap } from './keyword';
 export type { Participant } from './participant';
 export type { ParticipantItem } from './ParticipantItem';
 export type { KeywordResponse } from './response';

--- a/frontend/src/types/keyword.ts
+++ b/frontend/src/types/keyword.ts
@@ -9,6 +9,10 @@ export interface Keywords {
   [questionId: number]: Keyword[];
 }
 
+export interface KeywordsCoordinates {
+  [keyword: string]: { x: number; y: number; count: number };
+}
+
 export interface PrefixSum {
   [count: number]: number;
 }

--- a/frontend/src/types/keyword.ts
+++ b/frontend/src/types/keyword.ts
@@ -5,6 +5,18 @@ export interface Keyword {
   count: number;
 }
 
+export interface Keywords {
+  [questionId: number]: Keyword[];
+}
+
+export interface PrefixSum {
+  [count: number]: number;
+}
+
+export interface PrefixSumMap {
+  [questionId: number]: PrefixSum;
+}
+
 export interface KeywordInfo {
   questionId: number;
   keyword: string;


### PR DESCRIPTION
close #23 

# ✅ 주요 작업

- [x] 질문에 대한 실시간 키워드들을 워드 클라우드 UI 레이아웃과 애니메이션으로 표시하기 ( #23 )
  - [x] 키워드들끼리 겹치지 않아야 한다
  - [x] 이미 존재하는 위치에 생성될 경우, 기존에 존재하는 요소를 밀어내는 애니메이션을 추가한다.
  - [x] 상위 키워드일수록 되도록 중앙에 위치해야 한다
    - [x] 중앙으로 이동하는 과정에서 애니메이션을 적용한다

https://github.com/user-attachments/assets/2679912e-a99d-40f3-93d2-9ad4efa5c8e5

# 📚 학습 키워드
`css position` `DOM APIs` `offset` `jQCloud`

# 💭 고민과 해결과정
- [워드 클라우드 UI 구현을 위한 방향성 고민](https://lime-mall-d34.notion.site/UI-107a6e9379ae4f58981c2ae8422fc147?pvs=4)
- [jQCloud 1.0.4 라이브러리의 워드클라우드 UI 구현 로직 분석](https://lime-mall-d34.notion.site/jQCloud-1-0-4-UI-277692f289c74294b24e1c4a7325cb81?pvs=4)
- [jQCloud 오픈소스를 참고하여 React에서 워드 클라우드 UI 구현하기(작성중)](https://lime-mall-d34.notion.site/jQCloud-React-UI-6da0c8032008420899ecb5709aad4e3c?pvs=4)

# 📌 이슈 사항
- hidden 키워드 컨테이너와 실제 보여지는 키워드 컨테이너의 키워드 스타일의 차이 때문에 드물게 키워드끼리 살짝 겹치는 경우가 있긴 합니다
- 키워드 하나가 단순히 추가만 되는 경우 기존 키워드들의 자리를 비슷하게 유지하도록 개선할 예정입니다
- 키워드 컨테이너가 참여자 프로필 컨테이너의 내부에 있어서, 프로필들을 어떻게 숨길지 고민입니다.
