### PR TITLE
FE gitAction 스크립트 작성

### DIFF
--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -1,0 +1,63 @@
+name: Release Frontend Build
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. 리포지토리 클론
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # 2. Node.js 환경 설정
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      # 3. 의존성 설치
+      - name: Install dependencies
+        working-directory: ./frontend
+        run: npm ci
+
+      # 4. 빌드
+      - name: Build
+        working-directory: ./frontend
+        run: npm run build
+
+      # 5. 빌드된 파일을 인스턴스 서버로 전송
+      - name: Deploy to Instance
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          source: "frontend/dist/*"
+          target: "/tmp/build"
+          strip_components: 2
+
+      # 6. 백업 및 기존파일 삭제, 복사
+      - name: Configure Instance
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          script: |
+            # 기존 파일 백업
+            sudo tar -czf /var/www/backup/$(date +%Y%m%d_%H%M%S).tar.gz -C /var/www/html .
+
+            # 새 빌드 파일 복사
+            # sudo rm -rf /var/www/html/*
+            sudo cp -r /tmp/build/* /var/www/html/
+
+            # 권한 설정
+            sudo chown -R www-data:www-data /var/www/html
+
+            # Nginx 설정 파일의 유효성 검사 및 리로드(기존 연결을 끊지 않고 새로운 설정 적용)
+            sudo nginx -t && sudo systemctl reload nginx

--- a/.github/workflows/frontend-deploy.yml
+++ b/.github/workflows/frontend-deploy.yml
@@ -28,6 +28,8 @@ jobs:
       # 4. 빌드
       - name: Build
         working-directory: ./frontend
+        env:
+          VITE_SOCKET_SERVER_URL: ${{ secrets.VITE_SOCKET_SERVER_URL }}
         run: npm run build
 
       # 5. 빌드된 파일을 인스턴스 서버로 전송


### PR DESCRIPTION
close #58

# ✅ 주요 작업
- [x] release 브랜치에 반영시 FE 빌드파일을 인스턴스에 배포하는 `gitAction` 스크립트 작성
- [x] 프로젝트 `HTTPS` 적용`(let's encrypt)`


# 📚 학습 키워드
- `gitACtions`
- `let's encrypt`
# 💭 고민과 해결과정
## gitAction
- 처음에는 빌드 파일을 오브젝트 스토리지에 올리고 `nginx`에 제공하는 훅을 적용하는 식으로 하였지만 고가용성이 아니면 오브젝트스토리지를 안거쳐도 된다는 얘기를 통해 바로 인스턴스에 빌드 파일을 nginx 기본 index 가 있는 곳`/var/www/html/` 에 배포하여 프로젝트 접근시 프로젝트 랜딩페이지가 나오도록 하였습니다.
- 기존 스크립트(오브젝트 스토리지 업로드) : 
    ```
     # 5. PyYAML 및 AWS CLI 설치
          - name: Install dependencies
            run: |
              pip install --upgrade pip # 최신 버전의 pip로 업그레이드합니다.
              pip install PyYAML # awscli가 의존하는 PyYAML 라이브러리를 설치합니다.
              pip install awscli --upgrade --no-cache-dir # 최신 버전의 AWS CLI를 설치합니다.
    
          # 6. 빌드 파일 업로드
          - name: Deploy
            env: 
              AWS_ACCESS_KEY_ID: ${{ secrets.NCP_ACCESS_KEY }} # AWS CLI 인증정보 전
              AWS_SECRET_ACCESS_KEY: ${{ secrets.NCP_SECRET_KEY }}
            run: |
              aws --endpoint-url=https://kr.object.ncloudstorage.com s3 cp --recursive ./frontend/dist s3://load-to-friendly-bucket
    ```
- 수정 스크립트(바로 인스턴스에 배포)
  ```
   # 5. 빌드된 파일을 인스턴스 서버로 전송
        - name: Deploy to Instance
          uses: appleboy/scp-action@master
          with:
            host: ${{ secrets.SSH_HOST }}
            username: ${{ secrets.SSH_USERNAME }}
            key: ${{ secrets.SSH_KEY }}
            source: "frontend/dist/*"
            target: "/tmp/build"
            strip_components: 2
  
        # 6. 백업 및 기존파일 삭제, 복사
        - name: Configure Instance
          uses: appleboy/ssh-action@master
          with:
            host: ${{ secrets.SSH_HOST }}
            username: ${{ secrets.SSH_USERNAME }}
            key: ${{ secrets.SSH_KEY }}
            script: |
              # 기존 파일 백업
              sudo tar -czf /var/www/backup/$(date +%Y%m%d_%H%M%S).tar.gz -C /var/www/html .
  
              # 새 빌드 파일 복사
              # sudo rm -rf /var/www/html/*
              sudo cp -r /tmp/build/* /var/www/html/
  
              # 권한 설정
              sudo chown -R www-data:www-data /var/www/html
  
              # Nginx 설정 파일의 유효성 검사 및 리로드(기존 연결을 끊지 않고 새로운 설정 적용)
              sudo nginx -t && sudo systemctl reload nginx
  ```
## `HTTPS(let's encrypt)`
- 프로젝트의 HTTPS 적용을 위해서 `let's encrypt`를 적용하여 인증서를 발급하고 인증 갱신도 자동화로 처리하도록 하였습니다.
- [프로젝트](https://road-to-friendly.kro.kr/) 를 확인해보면 `HTTPS`가 적용되었습니다.
# 참고
- [FE CI/CD 관련정리](https://lime-mall-d34.notion.site/CI-CD-b1fc6491240f4f5894a9d942b76a5c3e?pvs=4)
# 📌 이슈 사항
- 현재는 FE 빌드 파일만 인스턴스에 배포된 상태이기 이벤트를 진행이 불가합니다 추후에 BE코드도 배포 예정입니다.