### PR TITLE
이미지 전송  기능 구현

### DIFF
--- a/frontend/src/assets/icons/deleteButton.svg
+++ b/frontend/src/assets/icons/deleteButton.svg
@@ -1,0 +1,4 @@
+<svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg">
+<ellipse cx="18" cy="18.6002" rx="18" ry="17.4" fill="black"/>
+<path d="M23.8022 21.5977H12.2006V17.4668H23.8022V21.5977Z" fill="white"/>
+</svg>

--- a/frontend/src/pages/room/content-share/enroll-modal-steps/enrollImageContent.tsx
+++ b/frontend/src/pages/room/content-share/enroll-modal-steps/enrollImageContent.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 
 import { useModal } from '@/hooks/useModal';
 
-import { LoadingSpinner } from '@/components/common';
+import { LoadingSpinner, Toast } from '@/components/common';
 
 import DeleteButton from '@/assets/icons/deleteButton.svg?react';
 import Image from '@/assets/icons/image.svg?react';
@@ -132,6 +132,8 @@ const EnrollImageContent: StepComponentType = ({ changeStepIndex }) => {
           if (file) {
             handleFileSelect(file);
           }
+        } else {
+          openToast({ type: 'error', text: '이미지 파일만 가능합니다' });
         }
       }
     }

--- a/frontend/src/pages/room/content-share/enroll-modal-steps/enrollImageContent.tsx
+++ b/frontend/src/pages/room/content-share/enroll-modal-steps/enrollImageContent.tsx
@@ -1,7 +1,195 @@
+import { css } from '@emotion/react';
+import { useEffect, useState } from 'react';
+
+import { useModal } from '@/hooks/useModal';
+
+import { LoadingSpinner } from '@/components/common';
+
+import DeleteButton from '@/assets/icons/deleteButton.svg?react';
+import Image from '@/assets/icons/image.svg?react';
+import { useToast } from '@/hooks';
+import { useSocketStore } from '@/stores';
+import { flexStyle, Variables } from '@/styles';
+
 import { StepComponentType } from '../contentEnrollModal';
 
+const previewStyle = (isActive: boolean) => css`  
+  width: 100%;
+  height: 280px;
+  margin: auto;
+  background-color: ${Variables.colors.surface_default};
+  border-radius: 16px;
+  border: 3px dashed ${isActive ? Variables.colors.surface_black : Variables.colors.surface_alt};
+  ${flexStyle(15, 'column', 'center', 'center')};
+  cursor: pointer;
+  font: ${Variables.typography.font_medium_16}
+}`;
+
+const selectButtonStyle = css`
+  background-color: ${Variables.colors.surface_white};
+  padding: 12px 8px;
+  color: ${Variables.colors.surface_green_strong};
+  border: 1px solid ${Variables.colors.surface_green_strong};
+  border-radius: 12px;
+`;
+
+const imgShareButtonStyle = (isActive: boolean) => css`
+  width: 100%;
+  background-color: ${isActive ? Variables.colors.surface_green_strong : Variables.colors.surface_alt};
+  color: ${Variables.colors.text_white};
+  padding: 12px 8px;
+  border: none;
+  border-radius: 12px;
+`;
+
+const deleteButtonStyle = () => css`
+  position: absolute;
+  top: -10px;
+  right: -10px;
+  background: none;
+  border: none;
+  cursor: pointer;
+`;
+
 const EnrollImageContent: StepComponentType = ({ changeStepIndex }) => {
-  return <div></div>;
+  const { socket } = useSocketStore();
+  const { openToast } = useToast();
+  const { closeModal } = useModal();
+
+  const [isActive, setActive] = useState(false);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [fileData, setFileData] = useState<{ filename: string; buffer: ArrayBuffer } | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const handleDragStart = () => setActive(true);
+  const handleDragEnd = () => setActive(false);
+  const handleDrop = (event: React.DragEvent<HTMLLabelElement>) => {
+    event.preventDefault();
+
+    const file = event.dataTransfer.files[0];
+    if (file) handleFileSelect(file);
+  };
+
+  const handleInputChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) handleFileSelect(file);
+  };
+
+  const handleFileSelect = (file: File) => {
+    const maxSize = 5 * 1024 * 1024; // 5MB 제한
+    if (file.size > maxSize) {
+      openToast({ type: 'error', text: '파일 크기가 너무 큽니다! 최대 5MB까지 허용됩니다.' });
+      return;
+    }
+
+    const reader = new FileReader();
+
+    // 이미지 미리보기 URL 생성
+    reader.onload = (e) => {
+      setPreviewUrl(e.target?.result as string);
+    };
+
+    // 파일 buffer 생성
+    reader.onloadend = () => {
+      const bufferReader = new FileReader();
+      bufferReader.readAsArrayBuffer(file);
+      bufferReader.onload = () => {
+        setFileData({
+          filename: file.name,
+          buffer: bufferReader.result as ArrayBuffer
+        });
+      };
+    };
+
+    reader.readAsDataURL(file);
+    handleDragStart();
+  };
+
+  const resetImagePreview = () => {
+    setPreviewUrl(null);
+    handleDragEnd();
+  };
+
+  const shareImage = () => {
+    setLoading(true);
+    socket.emit(
+      'interest:image',
+      { filename: fileData.filename, buffer: fileData.buffer },
+      (response: { status: string }) => {
+        response.status === 'ok' ? closeModal() : openToast({ type: 'error', text: '사진 공유에 실패했습니다.' });
+        setLoading(false);
+      }
+    );
+  };
+
+  // 클립보드에서 이미지 붙여넣기 처리
+  const handlePaste = (event: ClipboardEvent) => {
+    const items = event.clipboardData?.items;
+    if (items) {
+      for (const item of items) {
+        if (item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) {
+            handleFileSelect(file);
+          }
+        }
+      }
+    }
+  };
+
+  useEffect(() => {
+    //클립보드 이벤트 리스너 추가
+    window.addEventListener('paste', handlePaste);
+
+    return () => {
+      window.removeEventListener('paste', handlePaste);
+    };
+  }, []);
+
+  return (
+    <div css={[flexStyle(15, 'column', 'center', 'center'), { width: '510px' }]}>
+      <label
+        css={previewStyle(isActive)}
+        onDragOver={(event) => event.preventDefault()}
+        onDragEnter={handleDragStart}
+        onDragLeave={handleDragEnd}
+        onDrop={handleDrop}
+      >
+        {previewUrl ? (
+          <div css={{ width: '100%', height: '100%', position: 'relative' }}>
+            <img src={previewUrl} css={{ width: '100%', height: '100%', objectFit: 'cover', borderRadius: '16px' }} />
+            <button css={deleteButtonStyle} onClick={resetImagePreview}>
+              <DeleteButton width={30} height={30} />
+            </button>
+          </div>
+        ) : (
+          <>
+            <input type="file" css={{ display: 'none' }} accept=".jpg,.jpeg,.png" onChange={handleInputChange} />
+            <Image width={50} height={50} fill={Variables.colors.surface_alt} />
+            <p>
+              이미지를 드래그 앤 드랍으로 업로드할 수 있어요.
+              <br />
+              혹은,
+            </p>
+            <div css={selectButtonStyle}>디바이스에서 파일을 선택할 수도 있어요.</div>
+          </>
+        )}
+      </label>
+      <button css={imgShareButtonStyle(isActive)} onClick={shareImage}>
+        {loading ? (
+          <div css={{ display: 'flex', justifyContent: 'center' }}>
+            <LoadingSpinner
+              roundSize="1.7rem"
+              emptyColor={`${Variables.colors.surface_white}50`}
+              fillColor={Variables.colors.surface_white}
+            />
+          </div>
+        ) : (
+          '제출하고 공유 시작하기✨'
+        )}
+      </button>
+    </div>
+  );
 };
 
 export default EnrollImageContent;


### PR DESCRIPTION
close #91

# ✅ 주요 작업
 - 지원하는 이미지 파일: jpeg, png, jpg
 - 이미지 파일 용량 제한 : 5mb
 - 이미지는 파일 탐색기, 드래그앤드롭, 클립보드 붙여넣기를 지원한다
 - 업로드된 이미지가 존재할 경우에만 입력 form은 이미지 미리보기로 변하며 하단의 제출하기 버튼이 활성화된다.
 - 첨부한 이미지를 제거할 수 있다.

> 작업 결과를 눈으로 확인할 수 있는 스크린샷 등이 있다면 첨부해주세요
![Animation](https://github.com/user-attachments/assets/c625a46e-7145-4e8d-b06e-a1833dcd6e96)

# 📚 학습 키워드
이미지 드래그앤드롭, paste

# 💭 고민과 해결과정
파일을 직접 선택하는것과 드래그앤드롭, 클립보드 복사 모두 다른 로직으로 구현된다.
특히 파일선택은 input태그의 onChange로, 드래그앤드롭은 onDrop 이벤트로 받아서 처리해야한다.
```ts
<label
        css={previewStyle(isActive)}
        onDragOver={(event) => event.preventDefault()}
        onDragEnter={handleDragStart}
        onDragLeave={handleDragEnd}
        onDrop={handleDrop}
      >
```
```ts
<input type="file" css={{ display: 'none' }} accept=".jpg,.jpeg,.png" onChange={handleInputChange} />
```
![image](https://github.com/user-attachments/assets/86368b10-7bac-4314-83d3-1deb114bcec8)
클립보드 붙여넣기 기능의 경우 윈도우객체의 paste 이벤트 헨들러를 등록해서 구현할 수 있다.
```ts
// 클립보드에서 이미지 붙여넣기 처리
  const handlePaste = (event: ClipboardEvent) => {
    const items = event.clipboardData?.items;
    if (items) {
      for (const item of items) {
        if (item.type.startsWith('image/')) {
          const file = item.getAsFile();
          if (file) {
            handleFileSelect(file);
          }
        }
      }
    }
  };

window.addEventListener('paste', handlePaste);
```

# 📌 이슈 사항
현재 서버쪽 이미지 전송 이벤트가 수정 중에 있어, 전송버튼을 눌러도 로딩인디케이터가 표시됩니다.