### PR TITLE
워드클라우드 UX 개선, 동일한 키워드를 재입력하여 공감 취소 처리 가능하도록 구현

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,10 +1,10 @@
 <!doctype html>
-<html lang="en">
+<html lang="ko-KR">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>친해지길</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/QuestionInput.tsx
+++ b/frontend/src/components/QuestionInput.tsx
@@ -2,14 +2,14 @@ import { css } from '@emotion/react';
 import { useState } from 'react';
 
 import { useToast } from '@/hooks';
-import { sendPickKeywordMessage } from '@/services';
+import { sendPickKeywordMessage, sendReleaseKeywordMessage } from '@/services';
 import { useSocketStore } from '@/stores';
 import { Variables } from '@/styles';
-import { KeywordResponse } from '@/types';
 
 interface QuestionInputProps {
   currentQuestionIndex: number;
-  onSubmit: (keyword: string, type: 'add') => void;
+  selectedKeywords: Set<string>;
+  onSubmit: (keyword: string, type: 'add' | 'delete') => void;
 }
 
 const inputStyle = css`
@@ -27,7 +27,7 @@ const inputStyle = css`
   opacity: 1;
 `;
 
-const QuestionInput = ({ currentQuestionIndex, onSubmit }: QuestionInputProps) => {
+const QuestionInput = ({ currentQuestionIndex, selectedKeywords, onSubmit }: QuestionInputProps) => {
   const [keyword, setKeyword] = useState('');
   const { openToast } = useToast();
   const { socket } = useSocketStore();
@@ -42,13 +42,20 @@ const QuestionInput = ({ currentQuestionIndex, onSubmit }: QuestionInputProps) =
 
     if (socket) {
       try {
-        await sendPickKeywordMessage(socket, currentQuestionIndex + 1, keyword); // 서버에 키워드 추가 요청
-        setKeyword('');
-        onSubmit(keyword, 'add'); // 내가 선택한 키워드에 추가
+        if (!selectedKeywords.has(keyword)) {
+          await sendPickKeywordMessage(socket, currentQuestionIndex + 1, keyword); // 서버에 키워드 추가 요청
+          openToast({ text: '답변을 제출했어요!', type: 'check' });
+          setKeyword('');
+          onSubmit(keyword, 'add'); // 내가 선택한 키워드에 추가
+        } else {
+          await sendReleaseKeywordMessage(socket, currentQuestionIndex + 1, keyword); // 서버에 키워드 공감 취소 요청
+          openToast({ text: '해당 키워드에 대해 공감을 취소했어요', type: 'check' });
+          setKeyword('');
+          onSubmit(keyword, 'delete');
+        }
       } catch (error) {
         if (error instanceof Error) openToast({ text: error.message, type: 'error' });
       }
-
     }
   }
 

--- a/frontend/src/pages/room/KeywordsView.tsx
+++ b/frontend/src/pages/room/KeywordsView.tsx
@@ -7,7 +7,7 @@ import { sendPickKeywordMessage, sendReleaseKeywordMessage } from '@/services';
 import { useSocketStore } from '@/stores';
 import { useKeywordsStore } from '@/stores/keywords';
 import { keywordStyleMap, scaleIn, Variables } from '@/styles';
-import { Group, Keyword, KeywordsCoordinates, PrefixSum } from '@/types';
+import { Group, Keyword, KeywordInfo, KeywordsCoordinates, PrefixSum } from '@/types';
 
 const KeywordsViewContainer = css`
   width: 100%;
@@ -78,23 +78,52 @@ function getKeywordGroup(keyword: Keyword, keywordCountSum: number, prefixSum: P
 const KeywordsView = ({ questionId, selectedKeywords, updateSelectedKeywords }: KeywordsViewProps) => {
   const { socket } = useSocketStore();
   const { openToast } = useToast();
-  const { keywords, prefixSumMap, upsertKeyword } = useKeywordsStore();
+  const { keywords, prefixSumMap, upsertMultipleKeywords } = useKeywordsStore();
   const containerRef = useRef<HTMLDivElement>(null);
   const [keywordsCoordinates, setKeywordsCoordinates] = useState<KeywordsCoordinates>({});
 
   useEffect(() => {
-    if (socket) {
-      socket.off('empathy:keyword:count');
+    const keywordQueue: KeywordInfo[] = [];
+    let updateTimeout: ReturnType<typeof setTimeout>;
 
-      socket.on('empathy:keyword:count', (response: { questionId: number; keyword: string; count: number }) => {
-        upsertKeyword(response);
+    const processQueue = () => {
+      if (keywordQueue.length > 0) {
+        const batchUpdateKeywords = [...keywordQueue];
+        keywordQueue.length = 0;
+
+        // 동일한 키워드가 있는 경우 공감수가 더 큰 값으로 업데이트
+        const groupedKeywords = batchUpdateKeywords.reduce<Record<string, Keyword>>((acc, curr) => {
+          const { keyword, count } = curr;
+          acc[keyword] = {
+            keyword,
+            count: acc[keyword]?.count ? Math.max(acc[keyword].count, count) : count
+          };
+          return acc;
+        }, {});
+
+        upsertMultipleKeywords(questionId, Object.values(groupedKeywords));
+      }
+    };
+
+    // 추가되었거나 공감수가 변경된 키워드들을 받아서 큐에 쌓아두고 일정 시간마다 한번씩 처리
+    if (socket) {
+      /* socket.off('empathy:keyword:count'); */
+      socket.on('empathy:keyword:count', (response: KeywordInfo) => {
+        keywordQueue.push(response);
+        if (!updateTimeout) {
+          updateTimeout = setTimeout(() => {
+            processQueue();
+            updateTimeout = undefined;
+          }, 1500);
+        }
       });
     }
 
     return () => {
       socket?.off('empathy:keyword:count');
+      clearTimeout(updateTimeout);
     };
-  }, [socket]);
+  }, [socket, questionId, upsertMultipleKeywords]);
 
   // 키워드 배열 업데이트될 때마다 워드 클라우드 그리기
   useEffect(() => {
@@ -213,6 +242,7 @@ const KeywordsView = ({ questionId, selectedKeywords, updateSelectedKeywords }: 
       }));
     };
 
+    setKeywordsCoordinates({}); // 이전 워드클라우드 좌표정보 초기화
     wordArray.forEach((word, index) => {
       drawOneWord(index, word);
     });
@@ -253,14 +283,14 @@ const KeywordsView = ({ questionId, selectedKeywords, updateSelectedKeywords }: 
                 KeywordStyle,
                 keywordStyleMap(selectedKeywords.has(keyword))[
                   getKeywordGroup(keywordObject, Object.keys(keywordsCoordinates).length, prefixSumMap[questionId])
-                ],
-                {
-                  left: keywordsCoordinates[keyword].x,
-                  top: keywordsCoordinates[keyword].y
-                }
+                ]
               ]}
               onClick={() => {
                 selectedKeywords.has(keyword) ? unpickKeyword(keyword) : pickKeyword(keyword);
+              }}
+              style={{
+                left: keywordsCoordinates[keyword].x,
+                top: keywordsCoordinates[keyword].y
               }}
             >
               {keywordObject.keyword}

--- a/frontend/src/pages/room/content-share/contentShareView.tsx
+++ b/frontend/src/pages/room/content-share/contentShareView.tsx
@@ -61,7 +61,6 @@ const ContentShareView = () => {
   const isHostOrSharer =
     currentContent && socket ? currentContent.sharerSocketId === socket.id || socket.id === hostId : false;
 
-  console.log('공유중인 컨텐츠', currentContent);
   useEffect(() => {
     if (socket) {
       socket.on('share:interest:broadcast', (response: NextContentResponse) => {

--- a/frontend/src/pages/room/questionsView.tsx
+++ b/frontend/src/pages/room/questionsView.tsx
@@ -204,7 +204,11 @@ const QuestionsView = ({
           >{`Q${currentQuestionIndex + 1}. ${questions[currentQuestionIndex].title}`}</h1>
           {showInput && (
             <div css={{ width: '100%', animation: `${fadeIn} 2s ease forwards` }}>
-              <QuestionInput currentQuestionIndex={currentQuestionIndex} onSubmit={updateSelectedKeywords} />
+              <QuestionInput
+                currentQuestionIndex={currentQuestionIndex}
+                selectedKeywords={selectedKeywords}
+                onSubmit={updateSelectedKeywords}
+              />
               <div css={progressWrapperStyle}>
                 <ClockIcon width="35px" height="35px" fill="#000" />
                 <progress


### PR DESCRIPTION
# ✅ 주요 작업
- [x] 워드클라우드 UI를 1.5초 간격으로 업데이트하도록 수정
- [x] 동일한 키워드를 입력창에서 다시 입력하여 공감 취소 처리가 가능하게 함
- [x] index.html 언어 및 title 변경 (`언어`: ko-KR, `title`: 친해지길)


https://github.com/user-attachments/assets/7c3d4d3f-2419-4dbe-a1c6-53a9900df64e



# 📚 학습 키워드
`고차함수`

# 💭 고민과 해결과정
### 워드클라우드 UX 개선하기
기존의 실시간 키워드 입력 및 워드클라우드 표시기능의 과정은 다음과 같습니다.

1. 유저가 입력창에서 키워드를 제출하거나 워드클라우드에서 특정 키워드를 클릭하면, 서버는 `{ keyword: 키워드명, count: 빈도수 }` 메시지를 클라이언트에 전달
2. 클라이언트는 해당 메시지를 받을 때마다 `keywords[questionId]`를 업데이트하고 워드클라우드를 다시 렌더링

워드클라우드를 한 번 그리는 비용이 크고, `keywords[questionId]`에 키워드를 `upsert` 할 때마다 `정렬 + 그룹핑`이 수행되고 있었기 때문에, 동시에 수십 명이 입력하는 경우 짧은 시간에 `키워드 추가 + 정렬 + 그룹핑 + 워드클라우드 렌더링`이 수십 번 일어나면서 브라우저에 과부하가 일어나는 문제가 발견됐습니다.

이를 해결하기 위해, **서버가 전달해주는 `{ keyword: 키워드명, count: 빈도수 }` 메시지를 1.5초동안 큐에 저장해 두었다가, 1.5초가 경과할 때마다 큐에 있던 키워드들을 한꺼번에 `keywords[questionId]`에 업데이트하고 워드클라우드를 렌더링하도록 변경**했습니다.

```ts
useEffect(() => {
    const keywordQueue: KeywordInfo[] = [];
    let updateTimeout: ReturnType<typeof setTimeout>;

    const processQueue = () => {
      if (keywordQueue.length > 0) {
        const batchUpdateKeywords = [...keywordQueue];
        keywordQueue.length = 0;

        // 동일한 키워드가 있는 경우 공감수가 더 큰 값으로 업데이트
        const groupedKeywords = batchUpdateKeywords.reduce<Record<string, Keyword>>((acc, curr) => {
          const { keyword, count } = curr;
          acc[keyword] = {
            keyword,
            count: acc[keyword]?.count ? Math.max(acc[keyword].count, count) : count
          };
          return acc;
        }, {});

        upsertMultipleKeywords(questionId, Object.values(groupedKeywords));
      }
    };

    // 추가되었거나 공감수가 변경된 키워드들을 받아서 큐에 쌓아두고 일정 시간마다 한번씩 처리
    if (socket) {
      /* socket.off('empathy:keyword:count'); */
      socket.on('empathy:keyword:count', (response: KeywordInfo) => {
        keywordQueue.push(response);
        if (!updateTimeout) {
          updateTimeout = setTimeout(() => {
            processQueue();
            updateTimeout = undefined;
          }, 1500);
        }
      });
    }

    return () => {
      socket?.off('empathy:keyword:count');
      clearTimeout(updateTimeout);
    };
  }, [socket, questionId, upsertMultipleKeywords]);
```

기존에 `keywords` 스토어에서 단일 키워드 객체 하나를 받아서 업데이트하는 `upsertKeyword`는 키워드 추가 후 정렬과 그룹핑도 수행하기 때문에, 큐에 담아두었던 키워드들을 `map(keyword => upsertKeyword(keyword))`로 처리하면 정렬과 그룹핑이 불필요하게 반복되기 때문에, 키워드 목록에 모두 추가한 다음 정렬과 그룹핑은 한 번만 마지막에 수행하는 `upsertMultipleKeywords` 함수를 따로 추가했습니다.

```ts
upsertMultipleKeywords: (questionId, newKeywords) => {
    set((state) => {
      const existingKeywords = state.keywords[questionId] || [];

      // 병합 및 count 업데이트
      // newKeywords에 포함된 키워드들은 count를 새로 덮어쓰고, 기존 키워드들은 count를 그대로 유지
      const keywordMap = new Map<string, number>();
      // 기존 키워드들은 count를 그대로 유지
      existingKeywords.forEach(({ keyword, count }) => {
        keywordMap.set(keyword, count);
      });

      // 새로운 키워드들은 count를 덮어쓰거나 추가
      newKeywords.forEach(({ keyword, count }) => {
        keywordMap.set(keyword, count);
      });

      // 병합 결과를 배열로 변환 후 정렬
      const mergedKeywords = Array.from(keywordMap.entries())
        .map(([keyword, count]) => ({ keyword, count }))
        .filter(({ count }) => count > 0)
        .sort((a, b) => b.count - a.count);

      // 새 PrefixSumMap 계산
      const updatedPrefixSumMap = {
        ...state.prefixSumMap,
        [questionId]: getPrefixSumMap(mergedKeywords)
      };

      return {
        keywords: {
          ...state.keywords,
          [questionId]: mergedKeywords
        },
        prefixSumMap: updatedPrefixSumMap
      };
    });
  },
```


테스트를 해 보았을 때, 1.5초가 사용자로 하여금 워드클라우드가 너무 자주 변경되지 않으면서, 자신이 키워드를 입력하거나 공감/취소 요청한 결과가 너무 늦게 반영된다는 느낌이 들지 않는 적당한 시간이라고 판단되었습니다.

# 📌 이슈 사항
