### PR TITLE
feat: 🎸 시작 이후엔 새로고침 시 알림창 띄우도록

### DIFF
--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -89,6 +89,11 @@ const Room = () => {
     }
   };
 
+  const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+    e.preventDefault();
+    e.returnValue = '';
+  };
+
   // 참여자 수가 변경될 때마다 반지름 계산
   useEffect(() => {
     calculateRadius(Object.keys(participants).length);
@@ -99,6 +104,15 @@ const Room = () => {
       increaseLongRadius();
     }
   }, [isResultView]);
+
+  useEffect(() => {
+    if (!isIntroViewActive) {
+      window.addEventListener('beforeunload', handleBeforeUnload);
+    }
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [isIntroViewActive]);
 
   if (!roomExists) return <RoomNotFoundError />;
 


### PR DESCRIPTION
# ✅ 주요 작업
- [x] 시작 이후에는 새로고침 전 알림창을 띄우도록 변경

![{DD216ED2-5BEE-412F-866D-9ECF9181701E}](https://github.com/user-attachments/assets/2b4d200f-e8fb-4f35-9e85-b79f422b12bd)


# 📚 학습 키워드
`BeforeUnload`

# 💭 고민과 해결과정

# 📌 이슈 사항
`BeforeUnload`를 통해 처리해주고 있는데, 해당 이벤트 리스너에서 e.preventDefault()를 호출하면 저렇게 새로고침 전 창이 뜨게 됩니다. 그런데 저 창을 커스텀할 수 없어서 새로고침시 방에 들어올 수 없다는 걸 더 명확히 안내할 수 없는 점이 아쉽네요.. 더 좋은 방법이 있다면 적용해보고 싶습니다