### PR TITLE
UI 개선

### DIFF
--- a/frontend/src/components/ParticipantListSidebar.tsx
+++ b/frontend/src/components/ParticipantListSidebar.tsx
@@ -52,7 +52,7 @@ const ParticipantListSidebar = () => {
       </button>
       <Modal position={'topLeft'} isOpen={isModalOpen} onClose={() => setIsModalOpen(false)}>
         <div css={ListContainerStyle}>
-          <div>참여자 리스트</div>
+          <div>{`참여자 리스트(${Object.keys(participants).length})`}</div>
           {Object.keys(participants).map((participantId) => (
             <div key={participantId} css={ParticipantItemStyle}>
               <Profile />

--- a/frontend/src/components/Player/Player.tsx
+++ b/frontend/src/components/Player/Player.tsx
@@ -1,13 +1,15 @@
-import { useSocketStore } from '@/stores';
 import { css } from '@emotion/react';
 import { useRef, useState } from 'react';
-import { divideSize, multiplySize } from '@/utils';
 import ReactPlayer from 'react-player';
+
+import { YOUTUBE_ERROR_MESSAGES } from '@/constants/youtube';
 import { useFraction, useToast } from '@/hooks';
+import { useSocketStore } from '@/stores';
 import { InterestYoutubeResponse, PlayerState, YoutubeRequestType } from '@/types';
-import { YOUTUBE_ERROR_MESSAGES } from '@/constants';
-import SharerDraggingIndicator from './SharerDraggingIndicator';
+import { divideSize, multiplySize } from '@/utils';
+
 import ControllerSection from './ControllerSection';
+import SharerDraggingIndicator from './SharerDraggingIndicator';
 import StateChangeIndicator from './StateChangeIndicator';
 import VideoOverlayToggle from './VideoOverlayToggle';
 

--- a/frontend/src/components/ProfileEditButton.tsx
+++ b/frontend/src/components/ProfileEditButton.tsx
@@ -101,7 +101,6 @@ const ProfileEditButton = () => {
         }
       }));
       setIsEditing(false);
-      setIsModalOpen(false);
     },
     [setParticipants]
   );

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -19,8 +19,8 @@ const profileStyle = (x: number, y: number, shortRadius: number, longRadius: num
 
 const profileImageStyle = (bgColor: string) => css`
   position: relative;
-  width: 90px;
-  height: 90px;
+  width: 100px;
+  height: 100px;
   background-color: ${bgColor};
   border-radius: 50%;
   display: flex;
@@ -32,7 +32,7 @@ const profileImageStyle = (bgColor: string) => css`
 `;
 
 const participantNicknameStyle = css`
-  font-size: 16px;
+  font-size: 15px;
   font-weight: bold;
   color: ${Variables.colors.text_default};
 `;

--- a/frontend/src/constants/radius.ts
+++ b/frontend/src/constants/radius.ts
@@ -6,7 +6,3 @@ export const MAX_LONG_RADIUS = Math.floor((MAX_SHORT_RADIUS * 4) / 3);
 export const BIG_THRESHOLD = 20;
 export const MIDEIUM_THRESHOLD = 40;
 export const SMALL_THRESHOLD = 60;
-
-export const YOUTUBE_ERROR_MESSAGES = {
-  NO_PLAYER: '플레이어 구성 중 문제가 발생해서 공유자와 화면을 동기화할 수 없어요!'
-} as const;

--- a/frontend/src/constants/radius.ts
+++ b/frontend/src/constants/radius.ts
@@ -1,7 +1,8 @@
-export const MIN_SHORT_RADIUS = 210; //반지름
-export const MIN_LONG_RADIUS = Math.floor((MIN_SHORT_RADIUS * 4) / 3); //장축:단축 = 4:3
-export const MAX_SHORT_RADIUS = 220;
-export const MAX_LONG_RADIUS = Math.floor((MAX_SHORT_RADIUS * 4) / 3);
+export const MIN_SHORT_RADIUS = Math.floor(window.innerHeight * 0.3); // 화면 높이의 30%로 최소 반지름 설정
+export const MIN_LONG_RADIUS = Math.floor((MIN_SHORT_RADIUS * 4) / 3); // 비율에 맞춰 장축 계산
+
+export const MAX_SHORT_RADIUS = Math.floor(window.innerHeight * 0.33); // 화면 높이의 35%로 최대 반지름 설정
+export const MAX_LONG_RADIUS = Math.floor((MAX_SHORT_RADIUS * 4) / 3); //장축:단축 = 4:3
 
 export const BIG_THRESHOLD = 20;
 export const MIDEIUM_THRESHOLD = 40;

--- a/frontend/src/constants/youtube.ts
+++ b/frontend/src/constants/youtube.ts
@@ -17,3 +17,7 @@ export const YOUTUBE_SHORTS_URL_REGEX =
 
 // 쇼츠 우클릭 후 복사한 URL: https://www.youtube.com/shorts/n2DcpqDK8C0
 export const YOUTUBE_SHORTS_URL_SIMPLE_REGEX = /^(?:https?:\/\/)?(?:www\.)?youtube\.com\/shorts\/([a-zA-Z0-9_-]+)/;
+
+export const YOUTUBE_ERROR_MESSAGES = {
+  NO_PLAYER: '플레이어 구성 중 문제가 발생해서 공유자와 화면을 동기화할 수 없어요!'
+} as const;

--- a/frontend/src/pages/room/KeywordsView.tsx
+++ b/frontend/src/pages/room/KeywordsView.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { useEffect, useRef, useState } from 'react';
 
-import { BIG_THRESHOLD, MIDEIUM_THRESHOLD, SMALL_THRESHOLD } from '@/constants';
+import { BIG_THRESHOLD, MIDEIUM_THRESHOLD, SMALL_THRESHOLD } from '@/constants/radius';
 import { useToast } from '@/hooks';
 import { sendPickKeywordMessage, sendReleaseKeywordMessage } from '@/services';
 import { useSocketStore } from '@/stores';

--- a/frontend/src/pages/room/questionsView.tsx
+++ b/frontend/src/pages/room/questionsView.tsx
@@ -3,7 +3,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import ClockIcon from '@/assets/icons/clock.svg?react';
 import { QuestionInput } from '@/components';
-import { MAX_LONG_RADIUS } from '@/constants';
+import { MAX_LONG_RADIUS } from '@/constants/radius';
 import { useToast } from '@/hooks';
 import { useParticipantsStore, useQuestionsStore, useSocketStore, useKeywordsStore, useRadiusStore } from '@/stores/';
 import { flexStyle, Variables, fadeIn, fadeOut } from '@/styles';

--- a/frontend/src/pages/room/resultInstruction.tsx
+++ b/frontend/src/pages/room/resultInstruction.tsx
@@ -1,13 +1,32 @@
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 
 import { Variables } from '@/styles/Variables';
 
-const ResultInstructionStyle = css`
+// 페이드아웃 애니메이션 정의
+const fadeOut = keyframes`
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+`;
+
+const ResultInstructionStyle = (isFadingOut: boolean) => css`
   width: 100%;
   font: ${Variables.typography.font_bold_24};
   text-align: center;
+  opacity: ${isFadingOut ? 0 : 1};
+  animation: ${isFadingOut ? fadeOut : 'none'} 1s forwards; // 1초 동안 페이드아웃
+  transition: opacity 0.5s ease-in-out;
 `;
 
-const ResultInstruction = () => <div css={ResultInstructionStyle}>우리가 함께 지닌 공감 포인트들</div>;
+interface ResultInstructionProps {
+  isFadingOut: boolean;
+}
+
+const ResultInstruction = ({ isFadingOut }: ResultInstructionProps) => (
+  <div css={ResultInstructionStyle(isFadingOut)}>우리가 함께 지닌 공감 포인트들</div>
+);
 
 export default ResultInstruction;

--- a/frontend/src/pages/room/resultView.tsx
+++ b/frontend/src/pages/room/resultView.tsx
@@ -79,7 +79,7 @@ const ResultView = ({ participant }: ResultViewProps) => {
     }, {});
 
     setAllKeywords(ratioData);
-  }, []);
+  }, [statisticsKeywords]);
 
   return (
     <ul css={KeywordsContainer}>

--- a/frontend/src/pages/room/resultView.tsx
+++ b/frontend/src/pages/room/resultView.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import { useCallback, useEffect, useState } from 'react';
 
-import { BIG_THRESHOLD, MIDEIUM_THRESHOLD, SMALL_THRESHOLD } from '@/constants';
+import { BIG_THRESHOLD, MIDEIUM_THRESHOLD, SMALL_THRESHOLD } from '@/constants/radius';
 import { useSocketStore } from '@/stores';
 import { useKeywordsStore } from '@/stores/keywords';
 import { Variables, StatisticsStyleMap } from '@/styles';

--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
 import { useEffect, useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -60,6 +60,31 @@ const Room = () => {
 
   const [isIntroViewActive, setIsIntroViewActive] = useState(true);
   const [isResultView, setIsResultView] = useState(false); //결과 페이지 여부
+  const [isResultInstructionVisible, setIsResultInstructionVisible] = useState(true);
+  const [isFadingOut, setIsFadingOut] = useState(false); // 페이드아웃 상태
+  const [isContentShareVisible, setIsContentShareVisible] = useState(false);
+
+  useEffect(() => {
+    if (isResultView) {
+      setIsResultInstructionVisible(true);
+      // 5초 후 페이드아웃 시작
+      // 로딩이 3초
+      const fadeOutTimer = setTimeout(() => {
+        setIsFadingOut(true);
+      }, 5000);
+
+      // 페이드아웃 1초 후 ContentShareView 표시
+      const showContentTimer = setTimeout(() => {
+        setIsResultInstructionVisible(false);
+        setIsContentShareVisible(true);
+      }, 6000);
+
+      return () => {
+        clearTimeout(fadeOutTimer);
+        clearTimeout(showContentTimer);
+      };
+    }
+  }, [isResultView]);
 
   const startResultPage = () => {
     setIsResultView(true);
@@ -146,8 +171,8 @@ const Room = () => {
                     <LoadingPage isAnalyzing={true} />
                   ) : (
                     <>
-                      <ResultInstruction />
-                      <ContentShareView />
+                      {isResultInstructionVisible && <ResultInstruction isFadingOut={isFadingOut} />}
+                      {isContentShareVisible && <ContentShareView />}
                     </>
                   )
                 ) : (

--- a/frontend/src/stores/radius.ts
+++ b/frontend/src/stores/radius.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 
-import { MIN_SHORT_RADIUS, MIN_LONG_RADIUS, MAX_SHORT_RADIUS, MAX_LONG_RADIUS } from '@/constants';
+import { MIN_SHORT_RADIUS, MIN_LONG_RADIUS, MAX_SHORT_RADIUS, MAX_LONG_RADIUS } from '@/constants/radius';
 
 interface RadiusStore {
   radius: [number, number];


### PR DESCRIPTION
close #ISSUE-NUMBER

# ✅ 주요 작업
- 결과 표시 안내 -> 공유 대기 목록 페이드아웃 애니메이션 추가
- 참여자 리스트 총인원수 표시
- 닉네임 동시 수정 시 모달창이 같이 닫히는 오류 수정
- 타원의 반지름을 화면크기에 비례하게 설정
> 작업 결과를 눈으로 확인할 수 있는 스크린샷 등이 있다면 첨부해주세요

# 📚 학습 키워드

# 💭 고민과 해결과정
타원반지름을 뷰포트크기기준으로 설정했습니다.
```ts
export const MIN_SHORT_RADIUS = Math.floor(window.innerHeight * 0.3); // 화면 높이의 30%로 최소 반지름 설정
export const MIN_LONG_RADIUS = Math.floor((MIN_SHORT_RADIUS * 4) / 3); // 비율에 맞춰 장축 계산

export const MAX_SHORT_RADIUS = Math.floor(window.innerHeight * 0.33); // 화면 높이의 35%로 최대 반지름 설정
export const MAX_LONG_RADIUS = Math.floor((MAX_SHORT_RADIUS * 4) / 3); //장축:단축 = 4:3
```
# 📌 이슈 사항
