### PR TITLE
fix: 🐛 이슈사항들 해결, UI/UX 피드백 반영

### DIFF
--- a/frontend/src/components/Player/ControllerSection.tsx
+++ b/frontend/src/components/Player/ControllerSection.tsx
@@ -89,6 +89,7 @@ const ControllerSection = ({
   }
 
   return (
+    isHovering &&
     player && (
       <div>
         <div

--- a/frontend/src/components/Player/ControllerSection.tsx
+++ b/frontend/src/components/Player/ControllerSection.tsx
@@ -1,7 +1,8 @@
-import ReactPlayer from 'react-player';
-import { Slider } from '../common';
 import { useRef, useState } from 'react';
+import ReactPlayer from 'react-player';
 import { Socket } from 'socket.io-client';
+
+import { Slider } from '../common';
 import ControllBar from './ControllBar';
 
 interface ControllerSectionProps {
@@ -88,7 +89,6 @@ const ControllerSection = ({
   }
 
   return (
-    isHovering &&
     player && (
       <div>
         <div

--- a/frontend/src/components/Player/Player.tsx
+++ b/frontend/src/components/Player/Player.tsx
@@ -235,7 +235,7 @@ const Player = ({ url, isSharer, isShorts }: PlayerProps) => {
           config={{ youtube: { playerVars: { autoplay: 1 } } }}
         />
         <SharerDraggingIndicator isSharerDragging={isSharerDragging} />
-        {player && (
+        {isHovering && player && (
           <ControllerSection
             isHovering={isHovering}
             player={player}

--- a/frontend/src/components/Player/Player.tsx
+++ b/frontend/src/components/Player/Player.tsx
@@ -235,7 +235,7 @@ const Player = ({ url, isSharer, isShorts }: PlayerProps) => {
           config={{ youtube: { playerVars: { autoplay: 1 } } }}
         />
         <SharerDraggingIndicator isSharerDragging={isSharerDragging} />
-        {isHovering && player && (
+        {player && (
           <ControllerSection
             isHovering={isHovering}
             player={player}

--- a/frontend/src/components/ProfileEditButton.tsx
+++ b/frontend/src/components/ProfileEditButton.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import Edit from '@/assets/icons/edit.svg?react';
 import Profile from '@/assets/icons/profile.svg?react';
@@ -16,26 +16,22 @@ const profileImageStyle = css`
 `;
 
 const inputStyle = css`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   font: ${Variables.typography.font_medium_16};
   text-align: start;
   border-radius: 8px;
   border: 1px solid ${Variables.colors.surface_alt};
   padding: 5px;
-  width: 140px;
+  width: 130px;
 `;
 
 const editButtonStyle = css`
-  position: absolute;
-  width: 27px;
-  height: 27px;
   display: flex;
   justify-content: center;
   align-items: center;
-  right: 5px;
-  bottom: 5px;
   border: none;
-  border-radius: 50%;
-  background-color: ${Variables.colors.surface_black};
   cursor: pointer;
 `;
 
@@ -82,6 +78,7 @@ const ProfileEditButton = () => {
   const [isEditing, setIsEditing] = useState(false);
   const [nicknameInput, setNicknameInput] = useState('');
   const { participants, setParticipants } = useParticipantsStore();
+  const nickNameInputRef = useRef<HTMLInputElement>(null);
   const MAX_LENGTH = 6;
 
   const handleSaveNickname = () => {
@@ -130,6 +127,13 @@ const ProfileEditButton = () => {
     }
   }, [socket, connect, handleProfileUpdate]);
 
+  useEffect(() => {
+    if (isEditing && nickNameInputRef.current) {
+      setNicknameInput('');
+      nickNameInputRef.current.focus();
+    }
+  }, [isEditing]);
+
   return (
     <div>
       <button css={profileImageStyle} onClick={() => setIsModalOpen(true)}>
@@ -148,14 +152,9 @@ const ProfileEditButton = () => {
           <h3>내 프로필</h3>
           <div css={{ position: 'relative', width: '100px', height: '100px' }}>
             <Profile width={'100%'} height={'100%'} />
-            {!isEditing && (
-              <button css={editButtonStyle} onClick={() => setIsEditing(true)}>
-                <Edit width={'22px'} height={'22px'} />
-              </button>
-            )}
           </div>
           <div css={flexStyle(10)}>
-            <span>닉네임</span>
+            <span style={{ font: Variables.typography.font_medium_14 }}>닉네임</span>
             {isEditing ? (
               <div css={nicknameContainerStyle}>
                 <div css={wrapperStyle}>
@@ -165,6 +164,7 @@ const ProfileEditButton = () => {
                     maxLength={MAX_LENGTH}
                     onChange={handleInputChange}
                     placeholder="새 닉네임"
+                    ref={nickNameInputRef}
                   />
                   <span css={spanStyle}>{nicknameInput.length}/6</span>
                 </div>
@@ -174,7 +174,16 @@ const ProfileEditButton = () => {
               </div>
             ) : (
               <div css={nicknameContainerStyle}>
-                <div css={inputStyle}>{participants[socket?.id || '']?.nickname || '알 수 없음'}</div>
+                <div css={inputStyle}>
+                  {!isEditing && (
+                    <>
+                      <span>{participants[socket?.id || '']?.nickname || '알 수 없음'}</span>
+                      <button css={editButtonStyle} onClick={() => setIsEditing(true)}>
+                        <Edit width={'22px'} height={'22px'} fill={'#ff5b5b'} />
+                      </button>
+                    </>
+                  )}
+                </div>
               </div>
             )}
           </div>

--- a/frontend/src/components/ProfileEditButton.tsx
+++ b/frontend/src/components/ProfileEditButton.tsx
@@ -113,6 +113,12 @@ const ProfileEditButton = () => {
     }
   };
 
+  const handleEnterKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      handleSaveNickname();
+    }
+  };
+
   useEffect(() => {
     if (!socket) {
       connect();
@@ -163,6 +169,7 @@ const ProfileEditButton = () => {
                     value={nicknameInput}
                     maxLength={MAX_LENGTH}
                     onChange={handleInputChange}
+                    onKeyDown={handleEnterKeyDown}
                     placeholder="새 닉네임"
                     ref={nickNameInputRef}
                   />

--- a/frontend/src/components/ProfileEditButton.tsx
+++ b/frontend/src/components/ProfileEditButton.tsx
@@ -57,6 +57,7 @@ const profileEditContainerStyle = css`
   gap: 10px;
   min-width: 250px;
   height: 200px;
+  padding-top: 10px;
 `;
 
 const wrapperStyle = css`

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -4,7 +4,6 @@ import LinkIcon from '@/assets/icons/link.svg?react';
 import { useToast } from '@/hooks';
 import { hoverGrowJumpAnimation, Variables } from '@/styles';
 
-
 const shareButtonStyle = css({
   display: 'flex',
   justifyContent: 'space-around',
@@ -15,8 +14,8 @@ const shareButtonStyle = css({
   padding: '1rem',
 
   position: 'fixed',
-  bottom: '3rem',
-  right: '4rem',
+  bottom: '2rem',
+  right: '2rem',
 
   font: Variables.typography.font_medium_16,
   color: Variables.colors.text_default,
@@ -35,15 +34,13 @@ function copyCurrentLink(callback: Function) {
 const ShareButton = () => {
   const { openToast } = useToast();
   return (
-    <>
-      <button
-        css={[shareButtonStyle, hoverGrowJumpAnimation({ scale: 1.03, height: '0.6rem' })]}
-        onClick={() => copyCurrentLink(() => openToast({ text: '초대 링크가 복사되었습니다!', duration: 1250 }))}
-      >
-        <LinkIcon />
-        링크로 초대하기
-      </button>
-    </>
+    <button
+      css={[shareButtonStyle, hoverGrowJumpAnimation({ scale: 1.03, height: '0.6rem' })]}
+      onClick={() => copyCurrentLink(() => openToast({ text: '초대 링크가 복사되었습니다!', duration: 1250 }))}
+    >
+      <LinkIcon />
+      링크로 초대하기
+    </button>
   );
 };
 

--- a/frontend/src/components/ShareButton.tsx
+++ b/frontend/src/components/ShareButton.tsx
@@ -6,10 +6,10 @@ import { hoverGrowJumpAnimation, Variables } from '@/styles';
 
 const shareButtonStyle = css({
   display: 'flex',
-  justifyContent: 'space-around',
+  justifyContent: 'space-evenly',
   alignItems: 'center',
 
-  width: '12rem',
+  width: '180px',
   borderRadius: '1.75rem',
   padding: '1rem',
 

--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -10,11 +10,15 @@ const profileStyle = (x: number, y: number, shortRadius: number, longRadius: num
   position: absolute;
   left: ${longRadius + x}px;
   bottom: ${shortRadius + y}px;
-  transform: translate(-50%, 50%);
+  transform: translate(-50%, 50%) scale(1);
   transition: 1s ease-in-out;
   opacity: ${isOutOfBounds ? 0 : 1};
   transition: opacity 0.5s ease-in-out;
-  ${flexStyle(10, 'column', 'center', 'center')}
+  ${flexStyle(10, 'column', 'center', 'center')};
+
+  @media (min-height: 768px) and (max-height: 1200px) {
+    transform: translate(-50%, 50%) scale(0.8);
+  }
 `;
 
 const profileImageStyle = (bgColor: string) => css`

--- a/frontend/src/components/common/Slider.tsx
+++ b/frontend/src/components/common/Slider.tsx
@@ -1,6 +1,7 @@
-import { Variables } from '@/styles';
 import { css } from '@emotion/react';
 import { useEffect, useRef, useState } from 'react';
+
+import { Variables } from '@/styles';
 
 interface Color {
   empty?: string;
@@ -151,7 +152,6 @@ const Slider = ({
 
     const barLeft = sliderRef.current.getBoundingClientRect().left;
     const clickedX = e.clientX - barLeft;
-
     setFraction(clickedX / width);
   }
 
@@ -187,7 +187,7 @@ const Slider = ({
   }
 
   useEffect(() => {
-    if (sliderRef.current) setWidth(sliderRef.current.offsetWidth);
+    if (sliderRef.current) setWidth(sliderRef.current.getBoundingClientRect().width);
   }, []);
 
   return (
@@ -203,7 +203,12 @@ const Slider = ({
       >
         <div css={sliderEmptyStyle(bottom, mergedColor.empty, shouldHoverGrow)}></div>
         <div css={sliderFillStyle(fraction, mergedColor.fill, mergedColor.thumb, bottom, shouldHoverGrow)}></div>
-        {showThumb && <div className="thumb" css={thumbStyle(fraction, mergedColor.thumb, bottom, width)}></div>}
+        {showThumb && (
+          <div
+            className="thumb"
+            css={thumbStyle(fraction, mergedColor.thumb, bottom, sliderRef.current.offsetWidth)}
+          ></div>
+        )}
       </div>
     </>
   );

--- a/frontend/src/components/common/Slider.tsx
+++ b/frontend/src/components/common/Slider.tsx
@@ -203,7 +203,7 @@ const Slider = ({
       >
         <div css={sliderEmptyStyle(bottom, mergedColor.empty, shouldHoverGrow)}></div>
         <div css={sliderFillStyle(fraction, mergedColor.fill, mergedColor.thumb, bottom, shouldHoverGrow)}></div>
-        {showThumb && (
+        {sliderRef.current && showThumb && (
           <div
             className="thumb"
             css={thumbStyle(fraction, mergedColor.thumb, bottom, sliderRef.current.offsetWidth)}

--- a/frontend/src/pages/room/KeywordsView.tsx
+++ b/frontend/src/pages/room/KeywordsView.tsx
@@ -94,8 +94,9 @@ const KeywordsView = ({ questionId, selectedKeywords, updateSelectedKeywords }: 
 
     // 추가되었거나 공감수가 변경된 키워드들을 받아서 큐에 쌓아두고 일정 시간마다 한번씩 처리
     if (socket) {
-      /* socket.off('empathy:keyword:count'); */
       socket.on('empathy:keyword:count', (response: KeywordInfo) => {
+        if (response.questionId !== questionId) return;
+
         const { keyword, count } = response;
         keywordQueue.set(keyword, { keyword, count });
         if (!updateTimeout) {

--- a/frontend/src/pages/room/content-share/contentPresentSection.tsx
+++ b/frontend/src/pages/room/content-share/contentPresentSection.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/react';
 
-import { Content } from '@/types';
 import { Player } from '@/components';
-import { isShorts } from '@/utils';
 import { useSocketStore } from '@/stores';
+import { Content } from '@/types';
+import { isShorts } from '@/utils';
 
 const ContentPresentSectionStyle = css({
   flexGrow: 1,
@@ -33,6 +33,11 @@ const ContentPresentSection = ({ content }: ContentPresentSectionProps) => {
   const { socket } = useSocketStore();
   const isSharer = content.sharerSocketId === socket.id;
 
+  const parseIfPlaylistURL = (url: string) => {
+    const playlistPattern = /^https:\/\/www\.youtube\.com\/watch\?v=[\w-]+&list=[\w-]+/;
+    return playlistPattern.test(url) ? url.slice(0, url.indexOf('&list=')) : url;
+  };
+
   return (
     <>
       {content.type === 'IMAGE' && (
@@ -42,7 +47,11 @@ const ContentPresentSection = ({ content }: ContentPresentSectionProps) => {
       )}
       {content.type === 'YOUTUBE' && (
         <div css={ContentPresentSectionStyle}>
-          <Player url={content.resourceURL} isSharer={isSharer} isShorts={isShorts(content.resourceURL)} />
+          <Player
+            url={parseIfPlaylistURL(content.resourceURL)}
+            isSharer={isSharer}
+            isShorts={isShorts(content.resourceURL)}
+          />
         </div>
       )}
     </>

--- a/frontend/src/pages/room/content-share/contentShareView.tsx
+++ b/frontend/src/pages/room/content-share/contentShareView.tsx
@@ -17,7 +17,12 @@ const ContentShareViewStyle = css([
     height: '28.5625rem',
     backgroundColor: Variables.colors.surface_white,
     backgroundImage: `url("data:image/svg+xml,%3csvg width='100%25' height='100%25' xmlns='http://www.w3.org/2000/svg'%3e%3crect width='100%25' height='100%25' fill='none' rx='24' ry='24' stroke='%23B5B7BFFF' stroke-width='4' stroke-dasharray='6%2c 14' stroke-dashoffset='3' stroke-linecap='square'/%3e%3c/svg%3e")`,
-    borderRadius: 24
+    borderRadius: 24,
+    transform: 'scale(1)',
+
+    '@media (min-height: 768px) and (max-height: 1200px)': {
+      transform: 'scale(0.7)'
+    }
   },
   flexStyle(16, 'column')
 ]);

--- a/frontend/src/pages/room/room.tsx
+++ b/frontend/src/pages/room/room.tsx
@@ -190,7 +190,7 @@ const Room = () => {
                 )}
               </div>
             </div>
-            <ShareButton />
+            {isIntroViewActive && <ShareButton />}
           </div>
           <ParticipantListSidebar />
         </>


### PR DESCRIPTION
# ✅ 주요 작업
- [x] 이슈사항들 해결, UI 피드백 반영
  - [x] 재생목록에 있는 유튜브 URL 공유 시 재생목록 첫 번째 영상이 재생되는 버그
  - [x] 키워드 통계, 공유 뷰 겹침 문제
  - [x] 가끔 이전 질문에 대한 답변이 다음 질문 워드클라우드에 표시됨(1.5초 간격때문인듯)
  - [x] ‘관심사로 소통 시작하기’ 이후에 어차피 방에 들어와서 참여할 수 없다면, 링크로 초대하기 플로팅액션 버튼은 그때는 숨기기
  - [x] 프로필 수정 input창이 연필모양 버튼을 누르지 않으면 활성화되지 않아서 어리둥절했다. 연필모양 버튼역시 프로필 사진 수정 버튼인 줄 알았다 => 프로필 수정 input창 UX 개선

# 📚 학습 키워드
offsetWidth, offsetHeight, clientWidth, clientHeight, scrollWidth, scrollHeight, getBoundingClientRect()

# 💭 고민과 해결과정
### 재생목록에 있는 유튜브 URL 공유 시 재생목록 첫 번째 영상이 재생되는 버그

[`https://www.youtube.com/watch?v=D-WEeTsh-ls&list=PLquAuSkA-vzCZaYSfqqN6ojH00yHLifZt&index=159`](https://www.youtube.com/watch?v=D-WEeTsh-ls&list=PLquAuSkA-vzCZaYSfqqN6ojH00yHLifZt&index=159) 과 같이 재생목록 내 특정 index의 영상을 공유하면 해당 index가 아닌 첫 번째 영상이 재생되는 버그 발생.

공유 모달에서는 정상적으로 미리보기가 표시되고, 공유 후 `Player` 컴포넌트의 `url` prop에도 동일한 링크가 전달되는 것을 확인함. 아마도 `ReactPlayer`가 해당 포맷의 유튜브 URL을 지원하지 못하는 것으로 보임.

![image](https://github.com/user-attachments/assets/658a88f2-726a-45c8-a8ab-8148ebb48ec2)

따라서 [`https://www.youtube.com/watch?v=D-WEeTsh-ls&list=PLquAuSkA-vzCZaYSfqqN6ojH00yHLifZt&index=159`](https://www.youtube.com/watch?v=D-WEeTsh-ls[&list=PLquAuSkA-vzCZaYSfqqN6ojH00yHLifZt&index=159](https://www.youtube.com/watch?v=D-WEeTsh-ls&list=PLquAuSkA-vzCZaYSfqqN6ojH00yHLifZt&index=159)) 와 같은 포맷이 `ContentPresentSection`에 전달된 경우 [`&list=PLquAuSkA-vzCZaYSfqqN6ojH00yHLifZt&index=159`](https://www.youtube.com/watch?v=D-WEeTsh-ls&list=PLquAuSkA-vzCZaYSfqqN6ojH00yHLifZt&index=159) 쿼리를 빼고 `Player`에 전달함으로써 해결하였음

![image](https://github.com/user-attachments/assets/76d10d77-4048-42be-a722-4a30ad38ff93)

### 프로필 닉네임 수정 UI/UX 개선
- 닉네임 수정 버튼 위치를 프로필 아이콘 우측 하단에서, 닉네임란 내부 우측으로 변경
- 버튼 클릭 시 자동으로 input 창에 focus가 가도록 하고, 수정 후 Enter키를 눌러 저장할 수 있도록 개선

<img width="1054" alt="image" src="https://github.com/user-attachments/assets/1e476bfa-83cc-43a4-9fc6-aa65425b2770">

### 키워드 통계, 공유 뷰 겹침 문제
프로필 영역(타원형태) 장,단축 길이를 뷰포트 크기에 비례하도록 개선해주시고, 컨텐츠 공유 뷰 크기 역시 수정해주셨으나, 랩탑처럼 작은 화면에서는 프로필과 컨텐츠 공유 뷰 자체의 크기가 다소 커서 여전히 겹침 문제가 있었습니다. 또, 컨테이너 크기가 감소해도 내부의 글자 크기 등은 그대로라서 레이아웃이 망가지기도 했습니다.

그래서 뷰포트 높이가 일반적인 랩탑 화면 높이인 768px~1200px 사이인 경우 프로필과 컨텐츠 공유 뷰의 `transform: scale()`값을 작게 하여 모니터와 같이 넓은 화면이 아닌 랩탑 정도의 작은 화면에서 서로 겹치지 않으면서 레이아웃을 유지할 수 있게끔 개선했습니다.

27인치 모니터 화면 (화면이 커서 랩탑화면보다 스케일이 작아 보이지만 실제로는 scale: 1임)
<img width="2560" alt="image" src="https://github.com/user-attachments/assets/c69ee9bb-94fe-4e5f-bd8b-a6f8e35c482a">

14인치 랩탑 화면
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/9f364ace-67b5-43a5-b56b-9e7a0403ee11">

다만 `scale`을 변경했을 때 유튜브 커스텀 플레이어에서 마우스 커서 위치와 실제 슬라이더에 표시되는 위치가 맞지 않는 문제가 발생했는데, 이는 `sliderRef`의 길이를 `offsetWidth` 속성으로 얻고 있었기 때문입니다. 

`offsetWidth`, `offsetHeight`, `getBoundingClientRect()`는 대부분의 경우 엘리먼트의 높이와 너비를 리턴하지만, `offsetWidth`, `offsetHeight`는 엘리먼트의 `레이아웃`의 크기를 리턴하고 `getBoundingClientRect()`는 `렌더링된` 엘리먼트의 크기를 리턴합니다. 

그래서 `transform: scale`이 적용되어 있는 경우 실제 렌더링된 엘리먼트의 크기를 얻으려면 `getBoundingClientRect().width` 값을 가져와야 scale이 줄어든 슬라이더의 너비를 얻을 수 있었습니다.

[참고자료](https://m.blog.naver.com/apchima/220468669351)

# 📌 이슈 사항
