### PR TITLE
fix: 🐛 두 번째 영상 공유부터 영상 상태를 조작하면 뜨는 null 관련 에러 해결

### DIFF
--- a/frontend/src/components/Player/Player.tsx
+++ b/frontend/src/components/Player/Player.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import ReactPlayer from 'react-player';
 
 import { YOUTUBE_ERROR_MESSAGES } from '@/constants/youtube';
@@ -103,7 +103,6 @@ const Player = ({ url, isSharer, isShorts }: PlayerProps) => {
       player.getInternalPlayer().playVideo();
     } else {
       setIsPlaying(false);
-
       player.getInternalPlayer().pauseVideo();
     }
   }
@@ -191,6 +190,12 @@ const Player = ({ url, isSharer, isShorts }: PlayerProps) => {
 
     requestAnimationFrame(() => onProgressWithReqeustAnimation(callback));
   }
+
+  useEffect(() => {
+    return () => {
+      socket?.off('share:interest:youtube');
+    };
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
# ✅ 주요 작업
- [x] 두 번째 영상 공유부터 영상 상태를 조작하면 뜨는 null 관련 에러 해결

# 📚 학습 키워드

# 💭 고민과 해결과정
![{15E0CD86-FC6F-403E-B2DD-90223BBDE6C7}](https://github.com/user-attachments/assets/128ff222-cbb2-47e8-abf8-bced3d573fa2)

해당 에러는 흐름조작 권한이 없는 측, 즉 서버로부터 소켓 이벤트를 받는 쪽에서만 발생했습니다. 그래서 sync~로 시작하는 소켓 이벤트 핸들러에서 발생할 것이라고 추측했고, 개발자 도구로 확인해본 결과 syncWithSharerPlayOrPause가 두 번 실행되는 걸 발견했습니다. 또한 해당 함수에서 playVideo와 pauseVideo를 호출하는 player 객체가 두 번의 실행에서 다른 값을 가지는 것을 확인했습니다. 이는 `share:interest:youtube` 이벤트와 그 리스너를 부착하였으나 컴포넌트가 언마운트 될 때 off해주지 않아서, 이전에 부착해둔 리스너가 실행되어서 생긴 문제였습니다. 이전 리스너는 언마운트 이전 시점의 player를 클로저로 기억합니다. player의 getInternalPlayer()는 iframe으로 가져오는 플레이어의 API에 접근할 수 있는 함수인데, 언마운트된 이후에는 player가 기억하고 있는 iframe이 존재하지 않기 때문에 에러가 발생하게 됩니다.

useEffect를 통해 unmount될 때 해당 이벤트를 off해주게 함으로써 해결했습니다!


# 📌 이슈 사항
X