### PR TITLE
fix: 🐛 영상 실행 시, 이전 볼륨이 유지되도록 변경

### DIFF
--- a/frontend/src/components/Player/Player.tsx
+++ b/frontend/src/components/Player/Player.tsx
@@ -17,6 +17,7 @@ interface PlayerProps {
   url: string;
   isSharer: boolean;
   isShorts: boolean;
+  prevVolumeRef?: React.MutableRefObject<number | null>;
 }
 
 // 기본 플레이어의 비율은 16:9 비율
@@ -38,12 +39,12 @@ const wrapperStyle = css({
   userSelect: 'none'
 });
 
-const Player = ({ url, isSharer, isShorts }: PlayerProps) => {
+const Player = ({ url, isSharer, isShorts, prevVolumeRef }: PlayerProps) => {
   const [isPlaying, setIsPlaying] = useState(true);
   const [player, setPlayer] = useState<ReactPlayer | null>(null);
   const [fraction, setFraction] = useFraction(0);
   const [isHovering, setIsHovering] = useState(false);
-  const [volume, setVolume] = useFraction(0);
+  const [volume, setVolume] = useFraction(prevVolumeRef?.current ?? 0);
   const [isSharerDragging, setIsSharerDragging] = useState(false);
 
   const prevPlayedSecRef = useRef(0);
@@ -190,6 +191,12 @@ const Player = ({ url, isSharer, isShorts }: PlayerProps) => {
 
     requestAnimationFrame(() => onProgressWithReqeustAnimation(callback));
   }
+
+  useEffect(() => {
+    return () => {
+      if (prevVolumeRef !== undefined) prevVolumeRef.current = volume;
+    };
+  }, [volume]);
 
   useEffect(() => {
     return () => {

--- a/frontend/src/pages/room/content-share/contentPresentSection.tsx
+++ b/frontend/src/pages/room/content-share/contentPresentSection.tsx
@@ -26,10 +26,11 @@ const ImageContentStyle = css({
 
 interface ContentPresentSectionProps {
   content: Content;
+  prevVolumeRef?: React.MutableRefObject<number | null>;
 }
 
 /* 컨텐츠가 실제로 표시되는 영역 */
-const ContentPresentSection = ({ content }: ContentPresentSectionProps) => {
+const ContentPresentSection = ({ content, prevVolumeRef }: ContentPresentSectionProps) => {
   const { socket } = useSocketStore();
   const isSharer = content.sharerSocketId === socket.id;
 
@@ -51,6 +52,7 @@ const ContentPresentSection = ({ content }: ContentPresentSectionProps) => {
             url={parseIfPlaylistURL(content.resourceURL)}
             isSharer={isSharer}
             isShorts={isShorts(content.resourceURL)}
+            prevVolumeRef={prevVolumeRef}
           />
         </div>
       )}

--- a/frontend/src/pages/room/content-share/contentShareView.tsx
+++ b/frontend/src/pages/room/content-share/contentShareView.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import StopIcon from '@/assets/icons/stop.svg?react';
 import { useToast } from '@/hooks';
@@ -53,6 +53,8 @@ const ContentShareView = () => {
   const [currentContent, setCurrentContent] = useState<Content | null>(null);
   const [numberOfWaiters, setNumberOfWaiters] = useState(0);
 
+  const prevVolumeRef = useRef<number | null>(null);
+
   const stopSharing = async () => {
     try {
       await sendShareStopRequest(socket);
@@ -103,7 +105,7 @@ const ContentShareView = () => {
       ) : (
         <>
           <WaitingListInfo numWaiting={numberOfWaiters} />
-          <ContentPresentSection content={currentContent} />
+          <ContentPresentSection content={currentContent} prevVolumeRef={prevVolumeRef} />
           {isHostOrSharer && (
             <button css={StopShareButtonStyle} onClick={stopSharing}>
               <StopIcon fill={Variables.colors.text_white} />


### PR DESCRIPTION
# ✅ 주요 작업
- [x] 영상 실행 시, 이전 볼륨이 유지되도록 변경

# 📚 학습 키워드

# 💭 고민과 해결과정
[volume, setVolume] 자체는 플레이어가 책임지는 게 맞다고 생각했습니다. 그래서 외부에서 prevVolumeRef를 주입하고, 언마운트될 때 volume값과 동기화되도록 작성하였습니다. useEffect의 클린업함수는 실행될 당시의 클로저를 기억하기 때문에, 종속성 배열에 volume을 추가해 매번 갱신된 volume을 클린업 함수가 기억하도록 하였습니다.

# 📌 이슈 사항
contentShareView => contentPresentSection => Player 라는 드릴링이 생겼는데... 이전 볼륨 ref를 전역상태로 관리하는 건 더더욱 아닌 것 같고, 어쨌든 컨텐츠 공유를 총괄하는 `contentShareView`가 이전 볼륨값을 기억하는 건 책임에 맞는 것 같아서 이렇게 작성하는 편이 나은 것 같습니다. 더 좋은 방법이 있다면 알고 싶네요!