### PR TITLE
워드클라우드 reflow 횟수를 줄여서 성능 개선, 불필요한 KeywordsView 리렌더링 최적화

### DIFF
--- a/frontend/src/pages/room/content-share/waitingListEmpty.tsx
+++ b/frontend/src/pages/room/content-share/waitingListEmpty.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/react';
 
-import { flexStyle, Variables } from '@/styles';
 import { useModal } from '@/hooks/useModal';
+
+import { flexStyle, Variables } from '@/styles';
+
 import ContentEnrollModal from './contentEnrollModal';
 
 const WaitingListEmpty = () => {

--- a/frontend/src/pages/room/questionsView.tsx
+++ b/frontend/src/pages/room/questionsView.tsx
@@ -1,5 +1,5 @@
 import { css, keyframes } from '@emotion/react';
-import { useEffect, useRef, useState } from 'react';
+import { memo, useCallback, useEffect, useRef, useState } from 'react';
 
 import ClockIcon from '@/assets/icons/clock.svg?react';
 import { QuestionInput } from '@/components';
@@ -12,59 +12,6 @@ import { getRemainingSeconds } from '@/utils';
 import TimerWorker from '@/workers/timerWorker.js?worker';
 
 import KeywordsView from './KeywordsView';
-
-const MainContainer = css([{ width: '100%' }, flexStyle(5, 'column')]);
-
-const viewContainerStyle = (isFadeIn: boolean) => css`
-  width: ${MAX_LONG_RADIUS * 1.5}px;
-  animation: ${isFadeIn ? fadeIn : fadeOut} 0.5s ease;
-  opacity: ${isFadeIn ? 1 : 0};
-  ${flexStyle(8, 'column')}
-`;
-
-const moveUp = keyframes`
-  to {
-    transform: translate(-50%, -40px)
-  }
-`;
-
-const questionTitleStyle = (isQuestionMovedUp: boolean) =>
-  css({
-    position: 'absolute',
-    left: '50%',
-    transform: 'translateX(-50%)',
-    font: Variables.typography.font_bold_32,
-    marginBottom: Variables.spacing.spacing_sm,
-    animation: `${isQuestionMovedUp ? moveUp : 'none'} 1s ease forwards`
-  });
-
-const progressWrapperStyle = css([
-  {
-    width: '100%'
-  },
-  flexStyle(8, 'row')
-]);
-
-const progressBarStyle = css`
-  width: 100%;
-  height: 12px;
-  border-radius: 50px;
-  background-color: #eee;
-
-  ::-webkit-progress-bar {
-    background-color: ${Variables.colors.surface_alt};
-    border-radius: 50px;
-    height: 12px;
-    overflow: hidden;
-  }
-
-  ::-webkit-progress-value {
-    background-color: ${Variables.colors.surface_strong};
-    border-radius: 50px;
-    height: 12px;
-    transition: width 1s linear;
-  }
-`;
 
 interface QuestionViewProps {
   onQuestionStart: () => void;
@@ -95,16 +42,20 @@ const QuestionsView = ({
   const resultResponseRef = useRef<CommonResult | null>(null);
 
   const [selectedKeywords, setSelectedKeywords] = useState<Set<string>>(new Set());
-  const updateSelectedKeywords = (keyword: string, type: 'add' | 'delete') => {
-    if (type === 'add') {
-      setSelectedKeywords((prev) => new Set(prev.add(keyword)));
-    } else {
-      setSelectedKeywords((prev) => {
-        prev.delete(keyword);
-        return new Set(prev);
-      });
-    }
-  };
+
+  const updateSelectedKeywords = useCallback(
+    (keyword: string, type: 'add' | 'delete') => {
+      if (type === 'add') {
+        setSelectedKeywords((prev) => new Set(prev.add(keyword)));
+      } else {
+        setSelectedKeywords((prev) => {
+          prev.delete(keyword);
+          return new Set(prev);
+        });
+      }
+    },
+    [setSelectedKeywords]
+  );
 
   const handleResult = (response: CommonResult) => {
     // 통계결과를 임시로 저장
@@ -253,7 +204,6 @@ const QuestionsView = ({
               </div>
             </div>
           )}
-          <div></div>
         </div>
         <KeywordsView
           questionId={questions[currentQuestionIndex].questionId}
@@ -266,3 +216,56 @@ const QuestionsView = ({
 };
 
 export default QuestionsView;
+
+const MainContainer = css([{ width: '100%' }, flexStyle(5, 'column')]);
+
+const viewContainerStyle = (isFadeIn: boolean) => css`
+  width: ${MAX_LONG_RADIUS * 1.5}px;
+  animation: ${isFadeIn ? fadeIn : fadeOut} 0.5s ease;
+  opacity: ${isFadeIn ? 1 : 0};
+  ${flexStyle(8, 'column')}
+`;
+
+const moveUp = keyframes`
+  to {
+    transform: translate(-50%, -40px)
+  }
+`;
+
+const questionTitleStyle = (isQuestionMovedUp: boolean) =>
+  css({
+    position: 'absolute',
+    left: '50%',
+    transform: 'translateX(-50%)',
+    font: Variables.typography.font_bold_32,
+    marginBottom: Variables.spacing.spacing_sm,
+    animation: `${isQuestionMovedUp ? moveUp : 'none'} 1s ease forwards`
+  });
+
+const progressWrapperStyle = css([
+  {
+    width: '100%'
+  },
+  flexStyle(8, 'row')
+]);
+
+const progressBarStyle = css`
+  width: 100%;
+  height: 12px;
+  border-radius: 50px;
+  background-color: #eee;
+
+  ::-webkit-progress-bar {
+    background-color: ${Variables.colors.surface_alt};
+    border-radius: 50px;
+    height: 12px;
+    overflow: hidden;
+  }
+
+  ::-webkit-progress-value {
+    background-color: ${Variables.colors.surface_strong};
+    border-radius: 50px;
+    height: 12px;
+    transition: width 1s linear;
+  }
+`;


### PR DESCRIPTION
# ✅ 주요 작업
- [x] FE 최적화 작업
  - [x] 워드클라우드 reflow 횟수를 줄여서 성능 개선
  - [x] 불필요한 KeywordsView 리렌더링 최적화

# 📚 학습 키워드
`개발자 도구 Performance` `React Profiler` `useCallback` `React.memo` `reflow 최적화`

# 💭 고민과 해결과정
### QuestionsView

- `updateSelectedKeywords` 함수 `useCallback` 처리 ([**❗️문제상황:** `QuestionView`에서 props로 전달하는 함수 중 `updateSelectedKeywords`가 캐싱되지 않아 타이머가 동작할 때마다 워드 클라우드를 표시하는 `KeywordsView`가 1초마다 리렌더링되는 것을 확인. `KeywordsView`는 수많은 키워드들을 렌더링하기 때문에 업데이트 여부를 계산하더라도 최적화가 필요하다고 판단됨](https://www.notion.so/QuestionView-props-updateSelectedKeywords-KeywordsV-cfd169bbc3174f8cae3929fccc226fc4?pvs=21))
- 스타일코드 위치 컴포넌트 아래로 이동

### KeywordsView

- 스타일코드 위치 컴포넌트 아래로 이동
- 타이머 동작에 의한 리렌더링 최적화
    
    ![image](https://github.com/user-attachments/assets/5655ec1a-3b69-4380-b42b-829a54bf14c3)
    
    **❗️문제상황:** `QuestionView`에서 props로 전달하는 함수 중 `updateSelectedKeywords`가 캐싱되지 않아 타이머가 동작할 때마다 워드 클라우드를 표시하는 `KeywordsView`가 1초마다 리렌더링되는 것을 확인. `KeywordsView`는 수많은 키워드들을 렌더링하기 때문에 업데이트 여부를 계산하더라도 최적화가 필요하다고 판단됨
    
     💊 **해결방법:** `updateSelectedKeywords` 함수 `useCallback` 처리하고, `KeywordsView` 를 `React.memo` 처리하여 KeywordsView 내부 상태나 props가 변동되지 않는 한 리렌더링되지 않도록 최적화
    
     ✅ **결과:** 타이머가 동작에 KeywordsView가 영향을 받지 않고 키워드 추가/선택 시에만 리렌더링됨
    
   ![image](https://github.com/user-attachments/assets/105b5ef8-9d8b-4305-918e-2d62deb664d3)
    

- 워드클라우드 애니메이션 성능 측정 및 최적화, 리플로우 횟수 줄이기
    
    19개의 키워드 중 하나를 클릭하여 워드클라우드가 새로 그려질 때의 성능을 Performance > Event log 탭, React Profiler 탭으로 확인해보았다.
    
    ![image](https://github.com/user-attachments/assets/faacd2b0-aa61-4f85-9e6e-f5dc095a8b7d)
    
    워드 클라우드 키워드들이 배치될 좌표를 계산하는 `drawOneWord` 함수의 **Total time: 91.3ms**
    
    ![image](https://github.com/user-attachments/assets/454aa7c3-22c0-4f48-b16d-30d018526d25)
    
    리액트가 실제로 키워드들을 지정된 좌표에 렌더링하는 데 걸린 시간: **1.5ms**
    
    **❗️문제상황:** 엘리먼트의 크기를 계산하면서 트리거되는 잦은 리플로우의 횟수를 줄여야 한다. 실제로 `Forced reflow`가 자주 발생하여 빨간색으로 경고가 표시되는 걸 볼 수 있다.
    
    ![image](https://github.com/user-attachments/assets/f20fa722-0dd8-42fe-8641-1625cfe51e68)
    
    ![image](https://github.com/user-attachments/assets/3b0d92cb-e669-448d-ab54-27e95a27b311)
    
    **특히 키워드 1개를 어디에 위치시켜야 할지 랜덤으로 배정해보면서 `hitTest` 함수가 여러 번 호출되는데, `hitTest` 함수에서는 키워드가 해당 좌표에서 이미 배치된 다른 키워드들(**alreadyPlacedWords)**과 겹치는지 확인하기 위해  `overlapTest` 함수를** `alreadyPlacedWords.length` 만큼 반복한다.
    
    `overlapTest` 함수 내부에는 배치할 키워드(`a`)와 겹침을 확인할 타깃 키워드(`b`)의 `offset` 속성들을 함수가 실행될 때마다 얻어오는데, 이때 `reflow`를 발생시키게 된다.
    
    ```tsx
    // **키워드가 해당 좌표에서 이미 배치된 다른 키워드들(**alreadyPlacedWords)**과 겹치는지 확인하는 함수**
    const **hitTest** = (elem: HTMLElement, other_elems: HTMLElement[]): boolean => {
    
    	// **키워드가 해당 타깃 키워드와 겹치는지 확인하는 함수**
      const **overlapTest** = (a: HTMLElement, b: HTMLElement, gap: number) => {
        if (
          Math.abs(a.**offsetLeft** + a.**offsetWidth** / 2 - b.**offsetLeft** - b.**offsetWidth** / 2) <
          a.**offsetWidth** / 2 + b.**offsetWidth** / 2 + gap * 4
        ) {
          if (
            Math.abs(a.**offsetTop** + a.**offsetHeight** / 2 - b.**offsetTop** - b.**offsetHeight** / 2) <
            a.**offsetHeight** / 2 + b.**offsetHeight** / 2 + gap * 4
          ) {
            return true;
          }
        } else {
          return false;
        }
      };
    	
      let i = 0;
      for (i = 0; i < other_elems.length; i++) {
        if (overlapTest(elem, other_elems[i], 4)) return true;
      }
      return false;
    };
    
    // **키워드 1개를 어디에 위치시켜야 할지 랜덤으로 배정해보면서 hitTest 함수 실행**
    while (hitTest(wordSpan, alreadyPlacedWords)) {
      radius += step;
      angle += (index % 2 === 0 ? 1 : -1) * step;
      left = containerCenterX - width / 2 + radius * Math.cos(angle) * containerAspectRatio;
      top = containerCenterY + radius * Math.sin(angle) - height / 2.0;
      wordSpan.style.left = `${left}px`;
      wordSpan.style.top = `${top}px`;
    }
    ```
    
     💊 **해결방법:**  배치할 키워드(`a`)와 겹침을 확인할 타깃 키워드(`b`)의 크기가 다시 계산되지 않도록 `캐싱`하면 `reflow` 횟수를 대폭 줄일 수 있을 것이다.
    
    ```tsx
    interface OffsetValues {
      offsetWidth: number;
      offsetHeight: number;
      offsetLeft: number;
      offsetTop: number;
    }
    
    const **wordsOffsetValuesMap**: Record<string, OffsetValues> = {};
    
    ...
    
    alreadyPlacedWords.push(wordSpan);
    **// 배치된 키워드의 offset 속성들을 캐싱**
    wordsOffsetValuesMap[word.keyword] = {
      offsetLeft: left,
      offsetTop: top,
      offsetWidth: width,
      offsetHeight: height
    };
    ```
    
    이제 캐싱된 크기를 사용하여 `hitTest`를 실행하도록 변경하였다.
    
    ```tsx
    const hitTest = (elem: HTMLElement, other_elems: HTMLElement[]): boolean => {
      **const A_offsetValeus:** OffsetValues = {
        offsetLeft: elem.offsetLeft,
        offsetTop: elem.offsetTop,
        offsetWidth: elem.offsetWidth,
        offsetHeight: elem.offsetHeight
      };
    ****
      const overlapTest = (a: **OffsetValues**, b: **OffsetValues**, gap: number) => {
        if (
          Math.abs(a.offsetLeft + a.offsetWidth / 2 - b.offsetLeft - b.offsetWidth / 2) <
          a.offsetWidth / 2 + b.offsetWidth / 2 + gap * 4
        ) {
          if (
            Math.abs(a.offsetTop + a.offsetHeight / 2 - b.offsetTop - b.offsetHeight / 2) <
            a.offsetHeight / 2 + b.offsetHeight / 2 + gap * 4
          ) {
            return true;
          }
        } else {
          return false;
        }
      };
    
      let i = 0;
      for (i = 0; i < other_elems.length; i++) {
        if (**overlapTest(A_offsetValeus, wordsOffsetValuesMap[other_elems[i].innerText], 4)**) return true;
      }
      return false;
    };
    ```
    
    추가적으로 워드 클라우드를 그리는(hidden container) 작업을 `requestAnimationFrame` 으로 최적화하고, 지정된 좌표값을 업데이트하는 작업을 배치로 수행하게 수정했다.
    
    ```tsx
    const renderWords = () => {
      wordArray.forEach((word, index) => drawOneWord(index, word));
      setKeywordsCoordinates(updatedKeywordsCoordinates); 
    };
    
    requestAnimationFrame(renderWords);
    ```
    
     ✅ **결과:**  다시 동일한 키워드 목록을 가지고 워드 클라우드를 그릴 때의 성능을 측정해 보았더니 **Total time**이 **91.3ms → 16.2ms로 대폭 감소**한 것을 확인할 수 있었다. `reflow`가 잦다는 경고도 사라졌다.
    
   ![image](https://github.com/user-attachments/assets/38069e11-2d13-4fd0-8520-0deb5ec9174c)

# 📌 이슈 사항
