### PR TITLE
resize 이벤트에 따라 뷰포트기준으로 타원반지름 재계산

### DIFF
--- a/frontend/src/components/UserProfile.tsx
+++ b/frontend/src/components/UserProfile.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import Crown from '@/assets/icons/crown.svg?react';
 import { PROFILE_STYLES } from '@/constants/profile';
-import ResultView from '@/pages/room/resultView';
+import ResultView from '@/pages/room/ResultView';
 import { useRadiusStore } from '@/stores';
 import { Variables, flexStyle } from '@/styles';
 import { Participant } from '@/types';

--- a/frontend/src/constants/radius.ts
+++ b/frontend/src/constants/radius.ts
@@ -1,7 +1,7 @@
 export const MIN_SHORT_RADIUS = Math.floor(window.innerHeight * 0.3); // 화면 높이의 30%로 최소 반지름 설정
 export const MIN_LONG_RADIUS = Math.floor((MIN_SHORT_RADIUS * 4) / 3); // 비율에 맞춰 장축 계산
 
-export const MAX_SHORT_RADIUS = Math.floor(window.innerHeight * 0.33); // 화면 높이의 35%로 최대 반지름 설정
+export const MAX_SHORT_RADIUS = Math.floor(window.innerHeight * 0.35); // 화면 높이의 35%로 최대 반지름 설정
 export const MAX_LONG_RADIUS = Math.floor((MAX_SHORT_RADIUS * 4) / 3); //장축:단축 = 4:3
 
 export const BIG_THRESHOLD = 20;

--- a/frontend/src/stores/radius.ts
+++ b/frontend/src/stores/radius.ts
@@ -5,6 +5,7 @@ import { MIN_SHORT_RADIUS, MIN_LONG_RADIUS, MAX_SHORT_RADIUS, MAX_LONG_RADIUS } 
 interface RadiusStore {
   radius: [number, number];
   isOutOfBounds: boolean; // 화면 밖으로 벗어나는지 여부 플래그
+  setRadius: (radius: [number, number]) => void;
   increaseRadius: () => void;
   increaseLongRadius: () => void;
   setOutOfBounds: (isOutOfBounds: boolean) => void;
@@ -12,6 +13,7 @@ interface RadiusStore {
 
 export const useRadiusStore = create<RadiusStore>((set, get) => ({
   radius: [MIN_SHORT_RADIUS, MIN_LONG_RADIUS],
+  setRadius: (radius) => set({ radius }),
   isOutOfBounds: false,
   increaseRadius: () => set({ radius: [MAX_SHORT_RADIUS, MAX_LONG_RADIUS] }),
   increaseLongRadius: () => {

--- a/frontend/src/utils/arrangement.ts
+++ b/frontend/src/utils/arrangement.ts
@@ -14,3 +14,10 @@ export const calculatePosition = (count: number, shortRadius: number, longRadius
 
   return positions;
 };
+
+// 화면 크기가 변경될 때 반지름을 재계산하는 함수
+export const calculateRadius = (): [number, number] => {
+  const newShortRadius = Math.floor(window.innerHeight * 0.3);
+  const newLongRadius = Math.floor((newShortRadius * 4) / 3);
+  return [newShortRadius, newLongRadius];
+};

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,5 +1,5 @@
 export { parseNumberAndUnit, divideSize, multiplySize } from './calculateUtils';
-export { calculatePosition } from './arrangement';
+export { calculatePosition, calculateRadius } from './arrangement';
 export { getRemainingSeconds, convertSecToHHMMSS } from './time';
 export { convertArrayToObject } from './participantUtils';
 export { checkYoutubeURLValidation, getYoutubeEmbedURL, isShorts } from './youtube';


### PR DESCRIPTION
close #ISSUE-NUMBER

# ✅ 주요 작업
브라우저 창의 크기가 변경될 때 발생하는 이벤트인 `resize`의 이벤트핸들러로 타원의 반지름을 뷰포트 크기에 맞게 재계산하는 반응형 로직을 추가했습니다.
> 작업 결과를 눈으로 확인할 수 있는 스크린샷 등이 있다면 첨부해주세요

**resize 이벤트 적용 전**
![resize 이벤트 적용X](https://github.com/user-attachments/assets/8bb07522-16e8-464b-ad17-f351da4e9157)
**적용 후**
![resize 이벤트 적용](https://github.com/user-attachments/assets/2e997d03-1bbb-4aa7-a233-768c158b22eb)

# 📚 학습 키워드

# 💭 고민과 해결과정

# 📌 이슈 사항
